### PR TITLE
Used KeywordNames and KeywordParameter in necessary commands

### DIFF
--- a/src/Commands/ClassStartCommand.ts
+++ b/src/Commands/ClassStartCommand.ts
@@ -4,6 +4,7 @@ import { CommandResult } from "./CommandResult";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -19,13 +20,13 @@ export class ClassStartCommand extends Command {
         .withIndentation([1])
         .withParameters([
             new SingleParameter("classDescriptor", "The class name and optional generics.", true),
-            new SingleParameter(KeywordNames.Extends, "Keyword to extend from a parent class.", false),
+            new KeywordParameter([KeywordNames.Extends], "Keyword to extend from a parent class."),
             new SingleParameter("parentClassDescriptor", "A parent class name and optional generics.", false),
-            new SingleParameter(KeywordNames.Implements, "Keyword to implement from parent interface(s).", false),
+            new KeywordParameter([KeywordNames.Implements], "Keyword to implement from parent interface(s)."),
             new RepeatingParameters(
-                "Parent Interfaces",
+                "Parent interfaces",
                 [
-                    new SingleParameter("interfaceName", "Names of parent interfaces", false)
+                    new SingleParameter("interfaceName", "Names of parent interfaces.", false)
                 ])
         ]);
 

--- a/src/Commands/ConstructorStartCommand.ts
+++ b/src/Commands/ConstructorStartCommand.ts
@@ -4,6 +4,7 @@ import { CommandResult } from "./CommandResult";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -18,7 +19,7 @@ export class ConstructorStartCommand extends Command {
         .withDescription("Starts a constructor.")
         .withIndentation([1])
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the constructor.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the constructor."),
             new SingleParameter("className", "The name of the class.", true),
             new RepeatingParameters(
                 "Function parameters.",

--- a/src/Commands/FunctionStartCommand.ts
+++ b/src/Commands/FunctionStartCommand.ts
@@ -1,8 +1,10 @@
 import { Command } from "./Command";
 import { CommandNames } from "./CommandNames";
 import { CommandResult } from "./CommandResult";
+import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -25,6 +27,7 @@ export class FunctionStartCommand extends Command {
                     new SingleParameter("parameterName", "A named parameter for the function.", true),
                     new SingleParameter("parameterType", "The type of the parameter.", true)
                 ]),
+            new KeywordParameter([KeywordNames.Throws], "Keyword to list possible exceptions"),
             new RepeatingParameters(
                 "Possible exceptions.",
                 [

--- a/src/Commands/KeywordNames.ts
+++ b/src/Commands/KeywordNames.ts
@@ -30,7 +30,7 @@ export class KeywordNames {
     /**
      * Name keys for publicity keywords.
      */
-    public static Publicities: string[] = [
+    public static Privacies: string[] = [
         KeywordNames.Public,
         KeywordNames.Protected,
         KeywordNames.Private

--- a/src/Commands/MemberFunctionCommand.ts
+++ b/src/Commands/MemberFunctionCommand.ts
@@ -4,6 +4,7 @@ import { CommandNames } from "./CommandNames";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -17,7 +18,7 @@ export class MemberFunctionCommand extends Command {
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.MemberFunction)
         .withDescription("Starts a member function.")
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the function.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the function."),
             new SingleParameter("name", "The name of the function.", true),
             new SingleParameter("returnType", "Return type of the member function", true),
             new RepeatingParameters(

--- a/src/Commands/MemberFunctionDeclareStartCommand.ts
+++ b/src/Commands/MemberFunctionDeclareStartCommand.ts
@@ -5,6 +5,7 @@ import { CommandResult } from "./CommandResult";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -19,7 +20,7 @@ export class MemberFunctionDeclareStartCommand extends Command {
         .withDescription("Starts a member function.")
         .withIndentation([1])
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the function.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the function."),
             new SingleParameter("name", "The name of the function.", true),
             new SingleParameter("returnType", "The return type of the function.", true),
             new RepeatingParameters(
@@ -28,7 +29,7 @@ export class MemberFunctionDeclareStartCommand extends Command {
                     new SingleParameter("parameterName", "A named parameter for the function.", true),
                     new SingleParameter("parameterType", "The type of the parameter.", true)
                 ]),
-            new SingleParameter("throws", "Keyword to list possible exceptions.", false),
+            new KeywordParameter([KeywordNames.Throws], "Keyword to list possible exceptions"),
             new RepeatingParameters(
                 "Possible exceptions.",
                 [

--- a/src/Commands/MemberVariableCommand.ts
+++ b/src/Commands/MemberVariableCommand.ts
@@ -4,6 +4,7 @@ import { CommandNames } from "./CommandNames";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
 /**
@@ -16,7 +17,7 @@ export class MemberVariableCommand extends Command {
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.MemberVariable)
         .withDescription("Retrieves a member variable.")
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the member variable.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the member variable."),
             new SingleParameter("instanceName", "A class instance retrieving a member variable.", true),
             new SingleParameter("variableName", "The name of the member variable.", true)
         ]);

--- a/src/Commands/MemberVariableDeclareCommand.ts
+++ b/src/Commands/MemberVariableDeclareCommand.ts
@@ -4,6 +4,7 @@ import { CommandNames } from "./CommandNames";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
 /**
@@ -16,7 +17,7 @@ export class MemberVariableDeclareCommand extends Command {
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.MemberVariableDeclare)
         .withDescription("Declares a member variable.")
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the member variable.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the member variable."),
             new SingleParameter("name", "The name of the member variable.", true),
             new SingleParameter("type", "The type of the variable.", true)
         ]);

--- a/src/Commands/StaticFunctionCommand.ts
+++ b/src/Commands/StaticFunctionCommand.ts
@@ -4,6 +4,7 @@ import { CommandNames } from "./CommandNames";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -17,7 +18,7 @@ export class StaticFunctionCommand extends Command {
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.StaticFunction)
         .withDescription("Calls a static function.")
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the function.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the function."),
             new SingleParameter("className", "The name of the class the function is on.", true),
             new RepeatingParameters(
                 "Function parameters.",

--- a/src/Commands/StaticFunctionDeclareStartCommand.ts
+++ b/src/Commands/StaticFunctionDeclareStartCommand.ts
@@ -5,6 +5,7 @@ import { CommandResult } from "./CommandResult";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
@@ -19,7 +20,7 @@ export class StaticFunctionDeclareStartCommand extends Command {
         .withDescription("Starts a static function.")
         .withIndentation([1])
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the function.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the function."),
             new SingleParameter("name", "The name of the function.", true),
             new SingleParameter("returnType", "The return type of the function.", true),
             new RepeatingParameters(
@@ -28,7 +29,7 @@ export class StaticFunctionDeclareStartCommand extends Command {
                     new SingleParameter("parameterName", "A named parameter for the function.", true),
                     new SingleParameter("parameterType", "The type of the parameter.", true)
                 ]),
-            new SingleParameter("throws", "Keyword to list possible exceptions.", false),
+            new KeywordParameter([KeywordNames.Throws], "Keyword to list possible exceptions"),
             new RepeatingParameters(
                 "Possible exceptions.",
                 [

--- a/src/Commands/StaticVariableCommand.ts
+++ b/src/Commands/StaticVariableCommand.ts
@@ -4,6 +4,7 @@ import { CommandNames } from "./CommandNames";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
 /**
@@ -16,7 +17,7 @@ export class StaticVariableCommand extends Command {
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.StaticVariable)
         .withDescription("Retrieves a static variable.")
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the static variable.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the static variable."),
             new SingleParameter("className", "The name of the class the function is on.", true),
             new SingleParameter("variableName", "The name of the static variable.", true)
         ]);

--- a/src/Commands/StaticVariableDeclareCommand.ts
+++ b/src/Commands/StaticVariableDeclareCommand.ts
@@ -4,6 +4,7 @@ import { CommandNames } from "./CommandNames";
 import { KeywordNames } from "./KeywordNames";
 import { LineResults } from "./LineResults";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { KeywordParameter } from "./Metadata/Parameters/KeywordParameter";
 import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
 
 /**
@@ -16,7 +17,7 @@ export class StaticVariableDeclareCommand extends Command {
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.StaticVariableDeclare)
         .withDescription("Declares a static variable.")
         .withParameters([
-            new SingleParameter("privacy", "The privacy of the static variable.", true),
+            new KeywordParameter(KeywordNames.Privacies, "The privacy of the static variable."),
             new SingleParameter("name", "The name of the static variable.", true),
             new SingleParameter("type", "The type of the variable.", true),
             new SingleParameter("value", "An initial value for the variable.", false)

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
         "completed-docs": [false],
         "linebreak-style": [false],
         "max-line-length": [true, 175],
+        "member-ordering": [false],
         "newline-before-return": [false],
         "no-invalid-template-strings": [false],
         "no-magic-numbers": [false],


### PR DESCRIPTION
Disabled member-ordering because Privacies is a more standard name than Publicities and Privacies should come after Public/Protected/Private.

Fixes #319.