### PR TITLE
Exported NameSplitter; added convertToCase to converter bags

### DIFF
--- a/src/Conversions/Casing/CaseStyleConverterBag.ts
+++ b/src/Conversions/Casing/CaseStyleConverterBag.ts
@@ -55,4 +55,14 @@ export class CaseStyleConverterBag {
 
         return this.converters[caseStyleAlias];
     }
+
+    /**
+     * Combines a series of words to the equivalent case style.
+     *
+     * @param words   Words to convert.
+     * @returns The word's equivalent in the case style.
+     */
+    public convertToCase(caseStyle: CaseStyle, words: string[]): string {
+        return this.getConverter(caseStyle).convert(words);
+    }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { CaseStyleConverter } from "./Conversions/Casing/CaseStyleConverter";
 export { CaseStyleConverterBag } from "./Conversions/Casing/CaseStyleConverterBag";
+export { NameSplitter } from "./Conversions/Casing/NameSplitter";
 export { ConversionContext } from "./Conversions/ConversionContext";
 export { Command } from "./Commands/Command";
 export { CommandsBag } from "./Commands/CommandsBag";

--- a/test/unit/Conversions/Casing/CaseStyleConverterBagTests.ts
+++ b/test/unit/Conversions/Casing/CaseStyleConverterBagTests.ts
@@ -15,7 +15,7 @@ describe("CaseStyleConverterBag", () => {
             const command = caseStyleConverterBag.getConverter(CaseStyle.FileSystemLowerCase);
 
             // Assert
-            expect(command).that.be.instanceof(FileSystemLowerCaseConverter);
+            expect(command).to.be.instanceof(FileSystemLowerCaseConverter);
         });
 
         it("throws an error for an unknown case style", () => {
@@ -26,7 +26,31 @@ describe("CaseStyleConverterBag", () => {
             const action = () => caseStyleConverterBag.getConverter(-1);
 
             // Assert
-            expect(action).to.throw();
+            expect(action).to.throw(/Unknown case style requested(.*)/);
+        });
+    });
+
+    describe("convert", () => {
+        it("converts a case style by its enum", () => {
+            // Arrange
+            const caseStyleConverterBag = new CaseStyleConverterBag();
+
+            // Act
+            const converted = caseStyleConverterBag.convertToCase(CaseStyle.PascalCase, ["foo", "bar"]);
+
+            // Assert
+            expect(converted).to.be.equal("FooBar");
+        });
+
+        it("throws an error for an unknown case style", () => {
+            // Arrange
+            const caseStyleConverterBag = new CaseStyleConverterBag();
+
+            // Act
+            const action = () => caseStyleConverterBag.convertToCase(-1, ["foo", "bar"]);
+
+            // Assert
+            expect(action).to.throw(/Unknown case style requested(.*)/);
         });
     });
 });


### PR DESCRIPTION
TS-GLS wants both of these so it can mirror the same name splitting & converting logic as GLS.

Fixes #322. 