### PR TITLE
Moved imports to be native on NativeCallProperties

### DIFF
--- a/src/Commands/MathAbsoluteCommand.ts
+++ b/src/Commands/MathAbsoluteCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -23,13 +22,6 @@ export class MathAbsoluteCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
         return MathAbsoluteCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-        return this.language.properties.math.requiredImports;
     }
 
     /**

--- a/src/Commands/MathCeilingCommand.ts
+++ b/src/Commands/MathCeilingCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -23,13 +22,6 @@ export class MathCeilingCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
       return MathCeilingCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-      return this.language.properties.math.requiredImports;
     }
 
     /**

--- a/src/Commands/MathFloorCommand.ts
+++ b/src/Commands/MathFloorCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -23,13 +22,6 @@ export class MathFloorCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
         return MathFloorCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-        return this.language.properties.math.requiredImports;
     }
 
     /**

--- a/src/Commands/MathMaxCommand.ts
+++ b/src/Commands/MathMaxCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -24,13 +23,6 @@ export class MathMaxCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
         return MathMaxCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-        return this.language.properties.math.requiredImports;
     }
 
     /**

--- a/src/Commands/MathMinCommand.ts
+++ b/src/Commands/MathMinCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -24,13 +23,6 @@ export class MathMinCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
         return MathMinCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-        return this.language.properties.math.requiredImports;
     }
 
     /**

--- a/src/Commands/NativeCallCommand.ts
+++ b/src/Commands/NativeCallCommand.ts
@@ -55,7 +55,7 @@ export abstract class NativeCallCommand extends Command {
      * @returns Any imports this native command requires.
      */
     protected retrieveImports(): Import[] {
-        return [];
+        return this.nativeCallProperties.imports;
     }
 
     /**

--- a/src/Commands/StringCaseLowerCommand.ts
+++ b/src/Commands/StringCaseLowerCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -23,13 +22,6 @@ export class StringCaseLowerCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
         return StringCaseLowerCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-        return this.language.properties.strings.requiredImports;
     }
 
     /**

--- a/src/Commands/StringCaseUpperCommand.ts
+++ b/src/Commands/StringCaseUpperCommand.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Languages/Imports/Import";
 import { NativeCallProperties } from "../Languages/Properties/NativeCallProperties";
 import { CommandNames } from "./CommandNames";
 import { CommandMetadata } from "./Metadata/CommandMetadata";
@@ -23,13 +22,6 @@ export class StringCaseUpperCommand extends NativeCallCommand {
      */
     public getMetadata(): CommandMetadata {
         return StringCaseUpperCommand.metadata;
-    }
-
-    /**
-     * @returns Any imports this native command requires.
-     */
-    protected retrieveImports(): Import[] {
-        return this.language.properties.strings.requiredImports;
     }
 
     /**

--- a/src/Languages/CSharp.ts
+++ b/src/Languages/CSharp.ts
@@ -360,16 +360,18 @@ export class CSharp extends CLikeLanguage {
         lists.pop = new NativeCallProperties(
             "RemoveAt",
             NativeCallScope.Member,
-            NativeCallType.Function);
-
-        lists.pop.addArgument("{0}.Count - 1");
+            NativeCallType.Function)
+            .withArguments([
+                "{0}.Count - 1"
+            ]);
 
         lists.popFront = new NativeCallProperties(
             "RemoveAt",
             NativeCallScope.Member,
-            NativeCallType.Function);
-
-        lists.popFront.addArgument("0");
+            NativeCallType.Function)
+            .withArguments([
+                "0"
+            ]);
 
         lists.push = new NativeCallProperties(
             "Add",
@@ -444,32 +446,39 @@ export class CSharp extends CLikeLanguage {
      * @param math   A property container for metadata on math.
      */
     protected generateMathProperties(math: MathProperties): void {
-        math.absolute = new NativeCallProperties(
-            "Math.Abs",
-            NativeCallScope.Static,
-            NativeCallType.Function);
-        math.ceiling = new NativeCallProperties(
-            "Math.Ceiling",
-            NativeCallScope.Static,
-            NativeCallType.Function);
-        math.floor = new NativeCallProperties(
-            "Math.Floor",
-            NativeCallScope.Static,
-            NativeCallType.Function);
-        math.max = new NativeCallProperties(
-            "Math.Max",
-            NativeCallScope.Static,
-            NativeCallType.Function);
-        math.min = new NativeCallProperties(
-            "Math.Min",
-            NativeCallScope.Static,
-            NativeCallType.Function);
-        math.requiredImports = [
+        const requiredImports = [
             new Import(
                 ["system"],
                 ["Math"],
                 ImportRelativity.Absolute)
         ];
+
+        math.absolute = new NativeCallProperties(
+            "Math.Abs",
+            NativeCallScope.Static,
+            NativeCallType.Function)
+            .withImports(requiredImports);
+        math.ceiling = new NativeCallProperties(
+            "Math.Ceiling",
+            NativeCallScope.Static,
+            NativeCallType.Function)
+            .withImports(requiredImports);
+        math.floor = new NativeCallProperties(
+            "Math.Floor",
+            NativeCallScope.Static,
+            NativeCallType.Function)
+            .withImports(requiredImports);
+        math.max = new NativeCallProperties(
+            "Math.Max",
+            NativeCallScope.Static,
+            NativeCallType.Function)
+            .withImports(requiredImports);
+        math.min = new NativeCallProperties(
+            "Math.Min",
+            NativeCallScope.Static,
+            NativeCallType.Function)
+            .withImports(requiredImports);
+
         math.mathName = "Math";
     }
 
@@ -566,13 +575,6 @@ export class CSharp extends CLikeLanguage {
             "Length",
             NativeCallScope.Member,
             NativeCallType.Property);
-
-        strings.requiredImports = [
-            new Import(
-                ["system"],
-                [],
-                ImportRelativity.Absolute)
-        ];
     }
 
     /**

--- a/src/Languages/Java.ts
+++ b/src/Languages/Java.ts
@@ -363,16 +363,18 @@ export class Java extends CLikeLanguage {
         lists.pop = new NativeCallProperties(
             "remove",
             NativeCallScope.Member,
-            NativeCallType.Function);
-
-        lists.pop.addArgument("{0}.size() - 1");
+            NativeCallType.Function)
+            .withArguments([
+                "{0}.size() - 1"
+            ]);
 
         lists.popFront = new NativeCallProperties(
             "remove",
             NativeCallScope.Member,
-            NativeCallType.Function);
-
-        lists.popFront.addArgument("0");
+            NativeCallType.Function)
+            .withArguments([
+                "0"
+            ]);
 
         lists.push = new NativeCallProperties(
             "add",
@@ -463,7 +465,6 @@ export class Java extends CLikeLanguage {
             "Math.min",
             NativeCallScope.Static,
             NativeCallType.Function);
-        math.requiredImports = [];
         math.mathName = "Math";
     }
 
@@ -561,8 +562,6 @@ export class Java extends CLikeLanguage {
             "length",
             NativeCallScope.Member,
             NativeCallType.Function);
-
-        strings.requiredImports = [];
     }
 
     /**

--- a/src/Languages/JavaScript.ts
+++ b/src/Languages/JavaScript.ts
@@ -413,7 +413,6 @@ export class JavaScript extends CLikeLanguage {
             "Math.min",
             NativeCallScope.Static,
             NativeCallType.Function);
-        math.requiredImports = [];
         math.mathName = "Math";
     }
 
@@ -515,8 +514,6 @@ export class JavaScript extends CLikeLanguage {
             "length",
             NativeCallScope.Member,
             NativeCallType.Property);
-
-        strings.requiredImports = [];
     }
 
     /**

--- a/src/Languages/Properties/MathProperties.ts
+++ b/src/Languages/Properties/MathProperties.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Imports/Import";
 import { NativeCallProperties } from "../Properties/NativeCallProperties";
 
 /**
@@ -34,9 +33,4 @@ export class MathProperties {
      * How to retrieve the lower of two numbers.
      */
     public min: NativeCallProperties;
-
-    /**
-     * Required imports to be able to use native math commands.
-     */
-    public requiredImports: Import[];
 }

--- a/src/Languages/Properties/NativeCallProperties.ts
+++ b/src/Languages/Properties/NativeCallProperties.ts
@@ -1,3 +1,5 @@
+import { Import } from "../Imports/Import";
+
 /**
  * Where native operations are called from.
  */
@@ -53,9 +55,24 @@ export enum NativeCallType {
  */
 export class NativeCallProperties {
     /**
+     * Default arguments this may add as a function or static.
+     */
+    private static defaultArguments: string[] = [];
+
+    /**
+     * Default imports required for native command use.
+     */
+    private static defaultImports: Import[] = [];
+
+    /**
      * Any arguments this may add as a function or static.
      */
     public arguments: string[];
+
+    /**
+     * Any imports required for native command use.
+     */
+    public imports: Import[];
 
     /**
      * What this is called.
@@ -80,18 +97,32 @@ export class NativeCallProperties {
      * @param type   How this is called.
      */
     public constructor(name: string, scope: NativeCallScope, type: NativeCallType) {
+        this.arguments = NativeCallProperties.defaultArguments;
+        this.imports = NativeCallProperties.defaultImports;
         this.name = name;
         this.scope = scope;
         this.type = type;
-        this.arguments = [];
     }
 
     /**
-     * Adds an argument this may add as a function or static.
+     * Sets the arguments this may use as a function or static.
      *
-     * @param argument   A new argument.
+     * @param argument   Arguments this may use as a function or static.
+     * @returns this
      */
-    public addArgument(argument: string): void {
-        this.arguments.push(argument);
+    public withArguments(args: string[]): NativeCallProperties {
+        this.arguments = args;
+        return this;
+    }
+
+    /**
+     * Sets the imports required for native command use.
+     *
+     * @param imports   Imports required for native command use.
+     * @returns this
+     */
+    public withImports(imports: Import[]): NativeCallProperties {
+        this.imports = imports;
+        return this;
     }
 }

--- a/src/Languages/Properties/StringProperties.ts
+++ b/src/Languages/Properties/StringProperties.ts
@@ -1,4 +1,3 @@
-import { Import } from "../Imports/Import";
 import { NativeCallProperties } from "./NativeCallProperties";
 import { StringFormatProperties } from "./StringFormatProperties";
 import { StringSubstringProperties } from "./StringSubstringProperties";
@@ -46,9 +45,4 @@ export class StringProperties {
      * Metadata on the language's string substrings.
      */
     public substrings: StringSubstringProperties = new StringSubstringProperties();
-
-    /**
-     * Required imports to be able to use native string commands.
-     */
-    public requiredImports: Import[];
 }

--- a/src/Languages/Python.ts
+++ b/src/Languages/Python.ts
@@ -317,7 +317,9 @@ export class Python extends PythonicLanguage {
             "pop",
             NativeCallScope.Member,
             NativeCallType.Function);
-        lists.popFront.addArgument("0");
+        lists.popFront.withArguments([
+            "0"
+        ]);
 
         lists.push = new NativeCallProperties(
             "append",
@@ -396,7 +398,6 @@ export class Python extends PythonicLanguage {
             "min",
             NativeCallScope.Static,
             NativeCallType.Function);
-        math.requiredImports = [];
         math.mathName = "Math";
     }
 
@@ -501,8 +502,6 @@ export class Python extends PythonicLanguage {
             "len",
             NativeCallScope.Static,
             NativeCallType.Function);
-
-        strings.requiredImports = [];
     }
 
     /**

--- a/src/Languages/Ruby.ts
+++ b/src/Languages/Ruby.ts
@@ -409,7 +409,6 @@ export class Ruby extends PythonicLanguage {
             "min",
             NativeCallScope.Array,
             NativeCallType.Function);
-        math.requiredImports = [];
         math.mathName = "Math";
     }
 
@@ -507,8 +506,6 @@ export class Ruby extends PythonicLanguage {
             "length",
             NativeCallScope.Member,
             NativeCallType.Property);
-
-        strings.requiredImports = [];
     }
 
     /**

--- a/src/Languages/TypeScript.ts
+++ b/src/Languages/TypeScript.ts
@@ -428,7 +428,6 @@ export class TypeScript extends CLikeLanguage {
             "Math.min",
             NativeCallScope.Static,
             NativeCallType.Function);
-        math.requiredImports = [];
         math.mathName = "Math";
     }
 
@@ -530,8 +529,6 @@ export class TypeScript extends CLikeLanguage {
             "length",
             NativeCallScope.Member,
             NativeCallType.Property);
-
-        strings.requiredImports = [];
     }
 
     /**

--- a/test/integration/StringCaseLower/string case lower.cs
+++ b/test/integration/StringCaseLower/string case lower.cs
@@ -1,5 +1,3 @@
 //
-using System;
-
 aaa.ToLower();
 //

--- a/test/integration/StringCaseUpper/string case upper.cs
+++ b/test/integration/StringCaseUpper/string case upper.cs
@@ -1,5 +1,3 @@
 //
-using System;
-
 aaa.ToUpper();
 //


### PR DESCRIPTION
Arguments and imports are set as direct members with this-returning selfers. Removes the need for math and string requiredImports, and makes it easier for individual commands to specify different imports.

Fixes #351.