### PR TITLE
Use an external package to parse utils arguments

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -47,7 +47,7 @@ It requires overriding the abstract `retrieveNativeCallProperties` instead of `r
 ### Adding Languages
 
 Languages are stored at runtime by their language name in a `LanguagesBag`.
-You can add a new language by running `gulp util:new-language --name <name> --extension <extension> --baseName <baseName> --baseExtension <baseExtension>`.
+You can add a new language by running `gulp util:new-language --language-name <language-name> --language-extension <language-extension> --base-name <base-name> --base-extension <base-extension>`.
 
 Files and listings for a new language identical to the original language except for the name and extension will be added locally.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var getTsProject = (function () {
 
     return function (fileName, options) {
         if (!gulpTypeScript) {
-             gulpTypeScript = require("gulp-typescript");
+            gulpTypeScript = require("gulp-typescript");
         }
 
         if (!tsProjects[fileName]) {
@@ -239,32 +239,53 @@ gulp.task("util", function (callback) {
 });
 
 gulp.task("util:new-language", function () {
-    var program = require('commander');
+    // Creates an object literal yargs will accept with a few defaults
+    function createYargsOption(specifiedOptions) {
+        var defaultOptions = {
+            demandOption: true,
+            nargs: 1,
+        }
+        return Object.assign({}, defaultOptions, specifiedOptions);
+    }
 
-    program
-        .description('Adds a new language to GLS.')
-        .usage('util:new-language --language-name <language-name> --language-extension <language-extension> ' +
-               '--base-name <base-name> --base-extension <base-extension>')
-        .option('-n, --language-name <language-name>', 'name of the language to add')
-        .option('-e, --language-extension <language-extension>', 'extension for language files')
-        .option('-b, --base-name <base-name>', 'pre-existing language to use as a base')
-        .option('-x, --base-extension <base-extension>', 'extension to use as a base');
-    
-    program.parse(process.argv);
-    
+    // Ensures that an extension string passed in as an argument begins with a period
+    var extensionFormatCheck = function (extension) {
+        return (extension.charAt(0) !== '.') ? '.' + extension : extension;
+    }
+
+    var program = require('yargs')
+        .usage('Usage: gulp util:new-language --language-name <language-name> ' + 
+               '--language-extension <language-extension> --base-name <base-name> --base-extension <base-extension>')
+        .option('language-name', createYargsOption({
+            alias: 'n',
+            describe: 'name of the language to add',
+        }))
+        .option('language-extension', createYargsOption({
+            alias: 'e',
+            describe: 'extension for language files',
+            coerce: extensionFormatCheck,
+        }))
+        .option('base-name', createYargsOption({
+            alias: 'b',
+            describe: 'pre-existing language to use as a base',
+        }))
+        .option('base-extension', createYargsOption({
+            alias: 'x',
+            describe: 'extension to use as a base',
+            coerce: extensionFormatCheck,
+        }))
+        .argv;
+
     var name = program.languageName;
     var extension = program.languageExtension;
     var baseName = program.baseName;
     var baseExtension = program.baseExtension;
 
-    if (!name || !extension || !baseName || !baseExtension) {
-        program.help();
-    }
-
     console.log("Making new language with name '" + name + "' and extension '" + extension + "'.");
     console.log("Basing it off of name '" + baseName + "' and extension '" + baseExtension + "'.");
 
     var createNewLanguage = require("./util").createNewLanguage;
+
     createNewLanguage(
         {
             extension: extension,

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,37 +239,40 @@ gulp.task("util", function (callback) {
 });
 
 gulp.task("util:new-language", function () {
-    if (process.argv.length !== 11
-        || process.argv[3] !== "--name"
-        || process.argv[5] !== "--extension"
-        || process.argv[7] !== "--baseName"
-        || process.argv[9] !== "--baseExtension") {
-        console.error();
-        console.error("Invalid arguments passed to util:new-language.");
-        console.error("Arguments are case-insensitive and cannot be re-ordered.");
-        console.error();
-        console.error("Usage: gulp util:new-language --name <name> --extension <extension> --baseName <baseName> --baseExtension <baseExtension>");
-        console.error("Eample: gulp util:new-language JavaScript .js --baseName TypeScript --baseExtension .ts");
-        console.error();
-        return;
+    var program = require('commander');
+
+    program
+        .description('Adds a new language to GLS.')
+        .usage('util:new-language --language-name <language-name> --language-extension <language-extension> ' +
+               '--base-name <base-name> --base-extension <base-extension>')
+        .option('-n, --language-name <language-name>', 'name of the language to add')
+        .option('-e, --language-extension <language-extension>', 'extension for language files')
+        .option('-b, --base-name <base-name>', 'pre-existing language to use as a base')
+        .option('-x, --base-extension <base-extension>', 'extension to use as a base');
+    
+    program.parse(process.argv);
+    
+    var name = program.languageName;
+    var extension = program.languageExtension;
+    var baseName = program.baseName;
+    var baseExtension = program.baseExtension;
+
+    if (!name || !extension || !baseName || !baseExtension) {
+        program.help();
     }
 
-    var createNewLanguage = require("./util").createNewLanguage;
-    var name = process.argv[4];
-    var extension = process.argv[6];
-    var baseName = process.argv[8];
-    var baseExtension = process.argv[10];
     console.log("Making new language with name '" + name + "' and extension '" + extension + "'.");
     console.log("Basing it off of name '" + baseName + "' and extension '" + baseExtension + "'.");
 
+    var createNewLanguage = require("./util").createNewLanguage;
     createNewLanguage(
         {
             extension: extension,
-            name: name
+            name: name,
         },
         {
             extension: baseExtension,
-            name: baseName
+            name: baseName,
         });
 });
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "@types/node": "^8.0.28",
     "browserify": "^14.4.0",
     "chai": "^4.1.2",
-    "commander": "^2.11.0",
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-mocha": "^4.3.1",
@@ -39,6 +38,7 @@
     "tslint": "^5.7.0",
     "typescript": "^2.5.2",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.1.0"
+    "vinyl-source-stream": "^1.1.0",
+    "yargs": "^9.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/node": "^8.0.28",
     "browserify": "^14.4.0",
     "chai": "^4.1.2",
+    "commander": "^2.11.0",
     "del": "^3.0.0",
     "gulp": "^3.9.1",
     "gulp-mocha": "^4.3.1",


### PR DESCRIPTION
Description:

This PR adds [commander](https://github.com/tj/commander.js) to the project for `util:new-language` command processing.  Implementation is up for discussion - commander has a few limitations with respect to checking for required params that led to more safety checks than I originally intended.

For example, if a command has a flag defined on it such as:
```
 program
    .option('-n, --language-name <language-name>', 'name of the language to add')
    .parse(process.argv);
```
Omitting the value for the flag will throw an error:
```
$ gulp util:new-language --language-name       

error: option `-n, --language-name <language-name>' argument missing
```
Omitting both however, will not without additional checks:
```
$ gulp util:new-language
// Accepts input happily :-/
// console.log(program.languageName); will output undefined
```

Also, please let me know if anything else looks amiss!

Changes:
- Updated util:new-language to use commander for argument processing.
- Updated contributing doc