### PR TITLE
Added IfStringToFloat(Start|End) commands

### DIFF
--- a/src/Commands/Command.ts
+++ b/src/Commands/Command.ts
@@ -69,11 +69,12 @@ export abstract class Command {
             currentLine = new CommandResult("", 0);
             lines.push(currentLine);
 
-            endlineIndex = extra.indexOf("\n", currentIndex + 1);
+            currentIndex += 1;
+            endlineIndex = extra.indexOf("\n", currentIndex);
         }
 
         if (currentIndex !== -1) {
-            currentLine.text = extra.substring(currentIndex + 1);
+            currentLine.text = extra.substring(currentIndex);
         }
 
         lines[lines.length - 1].indentation = indentation;

--- a/src/Commands/CommandNames.ts
+++ b/src/Commands/CommandNames.ts
@@ -253,6 +253,16 @@ export class CommandNames {
     public static IfStart = "if start";
 
     /**
+     * Name key for the IfStringToFloatEnd command.
+     */
+    public static IfStringToFloatEnd = "if string to float end";
+
+    /**
+     * Name key for the IfStringToFloatStart command.
+     */
+    public static IfStringToFloatStart = "if string to float start";
+
+    /**
      * Name key for the ImportLocal command.
      */
     public static ImportLocal = "import local";

--- a/src/Commands/CommandsBagFactory.ts
+++ b/src/Commands/CommandsBagFactory.ts
@@ -52,6 +52,8 @@ import { FunctionStartCommand } from "./FunctionStartCommand";
 import { GenericTypeCommand } from "./GenericTypeCommand";
 import { IfEndCommand } from "./IfEndCommand";
 import { IfStartCommand } from "./IfStartCommand";
+import { IfStringToFloatEndCommand } from "./IfStringToFloatEndCommand";
+import { IfStringToFloatStartCommand } from "./IfStringToFloatStartCommand";
 import { ImportLocalCommand } from "./ImportLocalCommand";
 import { ImportPackageCommand } from "./ImportPackageCommand";
 import { InstanceOfCommand } from "./InstanceOfCommand";
@@ -247,6 +249,8 @@ export class CommandsBagFactory {
             new StringLengthCommand(context),
             new StringSubstringIndexCommand(context),
             new StringSubstringLengthCommand(context),
+            new IfStringToFloatStartCommand(context),
+            new IfStringToFloatEndCommand(context),
             new SuperConstructorCommand(context),
             new ThisCommand(context),
             new ThrowExceptionCommand(context),

--- a/src/Commands/IfStringToFloatEndCommand.ts
+++ b/src/Commands/IfStringToFloatEndCommand.ts
@@ -1,0 +1,22 @@
+import { BlockEndCommand } from "./BlockEndCommand";
+import { CommandNames } from "./CommandNames";
+import { CommandMetadata } from "./Metadata/CommandMetadata";
+
+/**
+ * Ends a block to be executed if a string can be converted to a float.
+ */
+export class IfStringToFloatEndCommand extends BlockEndCommand {
+    /**
+     * Metadata on the command.
+     */
+    private static metadata: CommandMetadata = new CommandMetadata(CommandNames.IfStringToFloatEnd)
+        .withDescription("Ends a block to be executed if a string can be converted to a float.")
+        .withIndentation([-1]);
+
+    /**
+     * @returns Metadata on the command.
+     */
+    public getMetadata(): CommandMetadata {
+        return IfStringToFloatEndCommand.metadata;
+    }
+}

--- a/src/Commands/IfStringToFloatStartCommand.ts
+++ b/src/Commands/IfStringToFloatStartCommand.ts
@@ -1,0 +1,154 @@
+import { Command } from "./Command";
+import { CommandNames } from "./CommandNames";
+import { CommandResult } from "./CommandResult";
+import { KeywordNames } from "./KeywordNames";
+import { LineResults } from "./LineResults";
+import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
+
+/**
+ * How a language attempts to convert strings to floats.
+ */
+export enum StringToFloatStartConversionType {
+    /**
+     * Convert strings into float variables and validate the results.
+     */
+    ConvertAndValidate,
+
+    /**
+     * Declare float variables, convert strings into them, and validate the results.
+     */
+    PredeclareConvertAndValidate,
+
+    /**
+     * Directly validate calls to float conversions inline.
+     */
+    ValidateDirectly,
+}
+
+/**
+ * Starts a block to be executed if a string can be converted to a float.
+ */
+export class IfStringToFloatStartCommand extends Command {
+    /**
+     * Metadata on the command.
+     */
+    private static metadata: CommandMetadata = new CommandMetadata(CommandNames.IfStringToFloatStart)
+        .withDescription("Starts a block to be executed if a string can be converted to a float.")
+        .withIndentation([1])
+        .withParameters([
+            new SingleParameter("stringName", "Name of a string to try converting.", true),
+            new SingleParameter("floatName", "What to call the string in float form.", true)
+        ]);
+
+    /**
+     * @returns Metadata on the command.
+     */
+    public getMetadata(): CommandMetadata {
+        return IfStringToFloatStartCommand.metadata;
+    }
+
+    /**
+     * Renders the command for a language with the given parameters.
+     *
+     * @param parameters   The command's name, followed by any parameters.
+     * @returns Line(s) of code in the language.
+     */
+    public render(parameters: string[]): LineResults {
+        const conversionType: StringToFloatStartConversionType = this.language.properties.strings.toFloat.conversionType;
+        const lines: CommandResult[] = [];
+
+        if (conversionType === StringToFloatStartConversionType.PredeclareConvertAndValidate) {
+            this.predeclareVariables(parameters, lines);
+        }
+
+        if (conversionType !== StringToFloatStartConversionType.ValidateDirectly) {
+            this.convertStrings(parameters, lines);
+        }
+
+        this.validateFloats(parameters, lines);
+
+        const results: LineResults = new LineResults(lines, false);
+
+        results.addImports(this.language.properties.strings.toFloat.requiredImports);
+
+        return results;
+    }
+
+    /**
+     * Adds pre-declared variables to the output lines.
+     *
+     * @param parameters   The command's name, followed by any parameters.
+     * @param lines   Output lines of rendered language code.
+     */
+    private predeclareVariables(parameters: string[], lines: CommandResult[]): void {
+        const initialValue = this.language.properties.strings.toFloat.initialVariableValues;
+
+        for (let i = 1; i < parameters.length; i += 2) {
+            const declarationParameters: string[] = [CommandNames.Variable, parameters[i + 1], KeywordNames.Float];
+
+            if (initialValue !== "") {
+                declarationParameters.push(initialValue);
+            }
+
+            const declaration = this.context.convertParsed(declarationParameters).commandResults[0];
+            declaration.text += this.language.properties.style.semicolon;
+            lines.push(declaration);
+        }
+
+        this.addLineEnder(lines, this.language.properties.strings.toFloat.initializeVariablesEnd, 0);
+    }
+
+    /**
+     * Adds string-to-float conversions to the output lines.
+     *
+     * @param parameters   The command's name, followed by any parameters.
+     * @param lines   Output lines of rendered language code.
+     */
+    private convertStrings(parameters: string[], lines: CommandResult[]): void {
+        if (lines.length === 0) {
+            lines.push(new CommandResult("", 0));
+        }
+
+        for (let i = 1; i < parameters.length; i += 2) {
+            const stringName = parameters[i];
+            const floatName = parameters[i + 1];
+
+            this.addLineEnder(lines, this.language.properties.strings.toFloat.perVariableConversionStartLeft, 0);
+            this.addLineEnder(lines, floatName, 0);
+            this.addLineEnder(lines, this.language.properties.strings.toFloat.perVariableConversionStartMiddle, 0);
+            this.addLineEnder(lines, stringName, 0);
+            this.addLineEnder(lines, this.language.properties.strings.toFloat.perVariableConversionStartRight, 0);
+        }
+    }
+
+    /**
+     * Adds float validation checks to the output lines.
+     *
+     * @param parameters   The command's name, followed by any parameters.
+     * @param lines   Output lines of rendered language code.
+     */
+    private validateFloats(parameters: string[], lines: CommandResult[]): void {
+        if (lines.length === 0) {
+            lines.push(new CommandResult("", 0));
+        }
+
+        this.addLineEnder(lines, this.language.properties.strings.toFloat.validationBlockLeft, 0);
+
+        for (let i = 1; i < parameters.length; i += 2) {
+            const stringName = parameters[i];
+            const floatName = parameters[i + 1];
+            const comparison = this.language.properties.strings.toFloat.validationBlockComparison
+                .replace("{0}", stringName)
+                .replace("{1}", floatName);
+
+            this.addLineEnder(lines, comparison, 0);
+
+            if (i < parameters.length - 2) {
+                this.addLineEnder(lines, this.language.properties.strings.toFloat.validationBlockMiddle, 0);
+            }
+        }
+
+        this.addLineEnder(lines, this.language.properties.strings.toFloat.validationBlockRight, 0);
+    }
+}

--- a/src/Commands/KeywordNames.ts
+++ b/src/Commands/KeywordNames.ts
@@ -18,6 +18,11 @@ export class KeywordNames {
     public static Extends = "extends";
 
     /**
+     * Name key for the "float" keyword.
+     */
+    public static Float = "float";
+
+    /**
      * Name key for the "implements" keyword.
      */
     public static Implements = "implements";
@@ -53,6 +58,11 @@ export class KeywordNames {
         KeywordNames.Public,
         KeywordNames.Protected
     ];
+
+    /**
+     * Name key for the "string" keyword.
+     */
+    public static String = "string";
 
     /**
      * Name key for the "throws" keyword.

--- a/src/Languages/CSharp.ts
+++ b/src/Languages/CSharp.ts
@@ -1,3 +1,4 @@
+import { StringToFloatStartConversionType } from "../Commands/IfStringToFloatStartCommand";
 import { CaseStyle } from "./Casing/CaseStyle";
 import { CLikeLanguage } from "./CLikeLanguage";
 import { Import } from "./Imports/Import";
@@ -34,6 +35,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties, StringSubstringSupport } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { StyleProperties } from "./Properties/StyleProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 
@@ -655,6 +657,27 @@ export class CSharp extends CLikeLanguage {
         substrings.middle = ", ";
         substrings.right = ")";
         substrings.support = StringSubstringSupport.Length;
+    }
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected generateStringToFloatProperties(toFloat: StringToFloatProperties): void {
+        toFloat.conversionType = StringToFloatStartConversionType.ValidateDirectly;
+
+        toFloat.requiredImports = [
+            new Import(
+                ["system"],
+                ["Float"],
+                ImportRelativity.Absolute)
+        ];
+
+        toFloat.validationBlockComparison = "float.TryParse({0}, out var {1})";
+        toFloat.validationBlockLeft = "if (";
+        toFloat.validationBlockMiddle = " && ";
+        toFloat.validationBlockRight = ")\n{";
     }
 
     /**

--- a/src/Languages/Java.ts
+++ b/src/Languages/Java.ts
@@ -1,3 +1,4 @@
+import { StringToFloatStartConversionType } from "../Commands/IfStringToFloatStartCommand";
 import { CaseStyle } from "./Casing/CaseStyle";
 import { CLikeLanguage } from "./CLikeLanguage";
 import { Import } from "./Imports/Import";
@@ -34,6 +35,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties, StringSubstringSupport } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 
 /**
@@ -632,6 +634,24 @@ export class Java extends CLikeLanguage {
         substrings.middle = ", ";
         substrings.right = ")";
         substrings.support = StringSubstringSupport.Index;
+    }
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected generateStringToFloatProperties(toFloat: StringToFloatProperties): void {
+        toFloat.conversionType = StringToFloatStartConversionType.PredeclareConvertAndValidate;
+        toFloat.initialVariableValues = "null";
+        toFloat.initializeVariablesEnd = "\n\ntry {\n";
+        toFloat.perVariableConversionStartLeft = "    ";
+        toFloat.perVariableConversionStartMiddle = " = Float.parseFloat(";
+        toFloat.perVariableConversionStartRight = ");\n";
+        toFloat.validationBlockComparison = "{1} != null";
+        toFloat.validationBlockLeft = "} catch (NumberFormatException e) { }\n\nif (";
+        toFloat.validationBlockMiddle = " && ";
+        toFloat.validationBlockRight = ") {";
     }
 
     /**

--- a/src/Languages/JavaScript.ts
+++ b/src/Languages/JavaScript.ts
@@ -1,3 +1,4 @@
+import { StringToFloatStartConversionType } from "../Commands/IfStringToFloatStartCommand";
 import { CaseStyle } from "./Casing/CaseStyle";
 import { CLikeLanguage } from "./CLikeLanguage";
 import { ArrayProperties } from "./Properties/ArrayProperties";
@@ -33,6 +34,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties, StringSubstringSupport } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 
 /**
@@ -579,6 +581,22 @@ export class JavaScript extends CLikeLanguage {
         substrings.middle = ", ";
         substrings.right = ")";
         substrings.support = StringSubstringSupport.Both;
+    }
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected generateStringToFloatProperties(toFloat: StringToFloatProperties): void {
+        toFloat.conversionType = StringToFloatStartConversionType.ConvertAndValidate;
+        toFloat.perVariableConversionStartLeft = "let ";
+        toFloat.perVariableConversionStartMiddle = " = parseFloat(";
+        toFloat.perVariableConversionStartRight = ");\n";
+        toFloat.validationBlockComparison = "!isNaN({1})";
+        toFloat.validationBlockLeft = "\nif (";
+        toFloat.validationBlockMiddle = " && ";
+        toFloat.validationBlockRight = ") {";
     }
 
     /**

--- a/src/Languages/Language.ts
+++ b/src/Languages/Language.ts
@@ -32,6 +32,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { StyleProperties } from "./Properties/StyleProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 
@@ -82,6 +83,7 @@ export abstract class Language {
         this.generateStringProperties(this.properties.strings);
         this.generateStringFormatProperties(this.properties.strings.formatting);
         this.generateStringSubstringProperties(this.properties.strings.substrings);
+        this.generateStringToFloatProperties(this.properties.strings.toFloat);
         this.generateStyleProperties(this.properties.style);
         this.generateVariableProperties(this.properties.variables);
 
@@ -316,18 +318,25 @@ export abstract class Language {
     protected abstract generateStringProperties(strings: StringProperties): void;
 
     /**
-     * Generates metadata on style.
-     *
-     * @param style   A property container for metadata on style.
-     */
-    protected abstract generateStyleProperties(style: StyleProperties): void;
-
-    /**
      * Generates metadata on string substrings.
      *
      * @param strings   A property container for metadata on string substrings.
      */
     protected abstract generateStringSubstringProperties(substrings: StringSubstringProperties): void;
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected abstract generateStringToFloatProperties(toFloat: StringToFloatProperties): void;
+
+    /**
+     * Generates metadata on style.
+     *
+     * @param style   A property container for metadata on style.
+     */
+    protected abstract generateStyleProperties(style: StyleProperties): void;
 
     /**
      * Generates metadata on variables.

--- a/src/Languages/Properties/StringProperties.ts
+++ b/src/Languages/Properties/StringProperties.ts
@@ -1,11 +1,17 @@
 import { NativeCallProperties } from "./NativeCallProperties";
 import { StringFormatProperties } from "./StringFormatProperties";
 import { StringSubstringProperties } from "./StringSubstringProperties";
+import { StringToFloatProperties } from "./StringToFloatProperties";
 
 /**
  * Metadata on a language's Strings.
  */
 export class StringProperties {
+    /**
+     * How to make a block to be executed if a string can be converted to a float.
+     */
+    public toFloat: StringToFloatProperties = new StringToFloatProperties();
+
     /**
      * How to create a lower-case copy of a string.
      */

--- a/src/Languages/Properties/StringToFloatProperties.ts
+++ b/src/Languages/Properties/StringToFloatProperties.ts
@@ -1,0 +1,62 @@
+import { StringToFloatStartConversionType } from "../../Commands/IfStringToFloatStartCommand";
+import { Import } from "../Imports/Import";
+
+/**
+ * Metadata on a language's string-to-float conversions.
+ */
+export class StringToFloatProperties {
+    /**
+     * How the language attempts to convert a strings to floats.
+     */
+    public conversionType: StringToFloatStartConversionType;
+
+    /**
+     * Initial value for each variable, if not "".
+     */
+    public initialVariableValues: string;
+
+    /**
+     * Text following variable initialization.
+     */
+    public initializeVariablesEnd: string;
+
+    /**
+     * Text before each variable is attempted to be converted.
+     */
+    public perVariableConversionStartLeft: string;
+
+    /**
+     * Text between variable conversion attempts.
+     */
+    public perVariableConversionStartMiddle: string;
+
+    /**
+     * Text after each variable is attempted to be converted.
+     */
+    public perVariableConversionStartRight: string;
+
+    /**
+     * Any imports required to convert strings to floats.
+     */
+    public requiredImports: Import[];
+
+    /**
+     * How each variable is checked for validity.
+     */
+    public validationBlockComparison: string;
+
+    /**
+     * Text before validating float variables.
+     */
+    public validationBlockLeft: string;
+
+    /**
+     * Text between each float variable validation.
+     */
+    public validationBlockMiddle: string;
+
+    /**
+     * Text after valiating float variables.
+     */
+    public validationBlockRight: string;
+}

--- a/src/Languages/Python.ts
+++ b/src/Languages/Python.ts
@@ -1,3 +1,4 @@
+import { StringToFloatStartConversionType } from "../Commands/IfStringToFloatStartCommand";
 import { CaseStyle } from "./Casing/CaseStyle";
 import { Import } from "./Imports/Import";
 import { ImportRelativity } from "./Imports/ImportRelativity";
@@ -32,6 +33,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties, StringSubstringSupport } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 import { PythonicLanguage } from "./PythonicLanguage";
 
@@ -557,6 +559,24 @@ export class Python extends PythonicLanguage {
             "len",
             NativeCallScope.Static,
             NativeCallType.Function);
+    }
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected generateStringToFloatProperties(toFloat: StringToFloatProperties): void {
+        toFloat.conversionType = StringToFloatStartConversionType.PredeclareConvertAndValidate;
+        toFloat.initialVariableValues = "None";
+        toFloat.initializeVariablesEnd = "\n\ntry:\n";
+        toFloat.perVariableConversionStartLeft = "    ";
+        toFloat.perVariableConversionStartMiddle = " = float(";
+        toFloat.perVariableConversionStartRight = ")\n";
+        toFloat.validationBlockComparison = "{1} is not None";
+        toFloat.validationBlockLeft = "except:\n    pass\n\nif ";
+        toFloat.validationBlockMiddle = " and ";
+        toFloat.validationBlockRight = ":";
     }
 
     /**

--- a/src/Languages/Ruby.ts
+++ b/src/Languages/Ruby.ts
@@ -1,3 +1,4 @@
+import { StringToFloatStartConversionType } from "../Commands/IfStringToFloatStartCommand";
 import { CaseStyle } from "./Casing/CaseStyle";
 import { ArrayProperties } from "./Properties/ArrayProperties";
 import { BooleanProperties } from "./Properties/BooleanProperties";
@@ -30,6 +31,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties, StringSubstringSupport } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 import { PythonicLanguage } from "./PythonicLanguage";
 
@@ -570,6 +572,22 @@ export class Ruby extends PythonicLanguage {
         substrings.middle = "..";
         substrings.right = "]";
         substrings.support = StringSubstringSupport.Length;
+    }
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected generateStringToFloatProperties(toFloat: StringToFloatProperties): void {
+        toFloat.conversionType = StringToFloatStartConversionType.ConvertAndValidate;
+        toFloat.perVariableConversionStartLeft = "";
+        toFloat.perVariableConversionStartMiddle = " = ";
+        toFloat.perVariableConversionStartRight = ".to_f\n";
+        toFloat.validationBlockComparison = "{1} != nil";
+        toFloat.validationBlockLeft = "\nif (";
+        toFloat.validationBlockMiddle = " && ";
+        toFloat.validationBlockRight = ")";
     }
 
     /**

--- a/src/Languages/TypeScript.ts
+++ b/src/Languages/TypeScript.ts
@@ -1,3 +1,4 @@
+import { StringToFloatStartConversionType } from "../Commands/IfStringToFloatStartCommand";
 import { CaseStyle } from "./Casing/CaseStyle";
 import { CLikeLanguage } from "./CLikeLanguage";
 import { ArrayProperties } from "./Properties/ArrayProperties";
@@ -33,6 +34,7 @@ import { SetProperties } from "./Properties/SetProperties";
 import { StringFormatProperties } from "./Properties/StringFormatProperties";
 import { StringProperties } from "./Properties/StringProperties";
 import { StringSubstringProperties, StringSubstringSupport } from "./Properties/StringSubstringProperties";
+import { StringToFloatProperties } from "./Properties/StringToFloatProperties";
 import { StyleProperties } from "./Properties/StyleProperties";
 import { VariableProperties } from "./Properties/VariableProperties";
 
@@ -596,6 +598,22 @@ export class TypeScript extends CLikeLanguage {
         substrings.middle = ", ";
         substrings.right = ")";
         substrings.support = StringSubstringSupport.Both;
+    }
+
+    /**
+     * Generates metadata on string-to-float conversions.
+     *
+     * @param toFloat   A property container for metadata on string-to-float conversions.
+     */
+    protected generateStringToFloatProperties(toFloat: StringToFloatProperties): void {
+        toFloat.conversionType = StringToFloatStartConversionType.ConvertAndValidate;
+        toFloat.perVariableConversionStartLeft = "let ";
+        toFloat.perVariableConversionStartMiddle = ": number = parseFloat(";
+        toFloat.perVariableConversionStartRight = ");\n";
+        toFloat.validationBlockComparison = "!isNaN({1})";
+        toFloat.validationBlockLeft = "\nif (";
+        toFloat.validationBlockMiddle = " && ";
+        toFloat.validationBlockRight = ") {";
     }
 
     /**

--- a/test/integration/IfStringToFloatStart/one variable.cs
+++ b/test/integration/IfStringToFloatStart/one variable.cs
@@ -1,0 +1,6 @@
+//
+using System;
+
+if (float.TryParse(aaa, out var bbb))
+{
+//

--- a/test/integration/IfStringToFloatStart/one variable.gls
+++ b/test/integration/IfStringToFloatStart/one variable.gls
@@ -1,0 +1,3 @@
+-
+if string to float start : aaa bbb
+-

--- a/test/integration/IfStringToFloatStart/one variable.java
+++ b/test/integration/IfStringToFloatStart/one variable.java
@@ -1,0 +1,9 @@
+//
+float bbb = null;
+
+try {
+    bbb = Float.parseFloat(aaa);
+} catch (NumberFormatException e) { }
+
+if (bbb != null) {
+//

--- a/test/integration/IfStringToFloatStart/one variable.js
+++ b/test/integration/IfStringToFloatStart/one variable.js
@@ -1,0 +1,5 @@
+//
+let bbb = parseFloat(aaa);
+
+if (!isNaN(bbb)) {
+//

--- a/test/integration/IfStringToFloatStart/one variable.py
+++ b/test/integration/IfStringToFloatStart/one variable.py
@@ -1,0 +1,10 @@
+#
+bbb = None
+
+try:
+    bbb = float(aaa)
+except:
+    pass
+
+if bbb is not None:
+#

--- a/test/integration/IfStringToFloatStart/one variable.rb
+++ b/test/integration/IfStringToFloatStart/one variable.rb
@@ -1,0 +1,5 @@
+#
+bbb = aaa.to_f
+
+if (bbb != nil)
+#

--- a/test/integration/IfStringToFloatStart/one variable.ts
+++ b/test/integration/IfStringToFloatStart/one variable.ts
@@ -1,0 +1,5 @@
+//
+let bbb: number = parseFloat(aaa);
+
+if (!isNaN(bbb)) {
+//

--- a/test/integration/IfStringToFloatStart/two variables.cs
+++ b/test/integration/IfStringToFloatStart/two variables.cs
@@ -1,0 +1,6 @@
+//
+using System;
+
+if (float.TryParse(aaa, out var bbb) && float.TryParse(ccc, out var ddd))
+{
+//

--- a/test/integration/IfStringToFloatStart/two variables.gls
+++ b/test/integration/IfStringToFloatStart/two variables.gls
@@ -1,0 +1,3 @@
+-
+if string to float start : aaa bbb ccc ddd
+-

--- a/test/integration/IfStringToFloatStart/two variables.java
+++ b/test/integration/IfStringToFloatStart/two variables.java
@@ -1,0 +1,11 @@
+//
+float bbb = null;
+float ddd = null;
+
+try {
+    bbb = Float.parseFloat(aaa);
+    ddd = Float.parseFloat(ccc);
+} catch (NumberFormatException e) { }
+
+if (bbb != null && ddd != null) {
+//

--- a/test/integration/IfStringToFloatStart/two variables.js
+++ b/test/integration/IfStringToFloatStart/two variables.js
@@ -1,0 +1,6 @@
+//
+let bbb = parseFloat(aaa);
+let ddd = parseFloat(ccc);
+
+if (!isNaN(bbb) && !isNaN(ddd)) {
+//

--- a/test/integration/IfStringToFloatStart/two variables.py
+++ b/test/integration/IfStringToFloatStart/two variables.py
@@ -1,0 +1,12 @@
+#
+bbb = None
+ddd = None
+
+try:
+    bbb = float(aaa)
+    ddd = float(ccc)
+except:
+    pass
+
+if bbb is not None and ddd is not None:
+#

--- a/test/integration/IfStringToFloatStart/two variables.rb
+++ b/test/integration/IfStringToFloatStart/two variables.rb
@@ -1,0 +1,6 @@
+#
+bbb = aaa.to_f
+ddd = ccc.to_f
+
+if (bbb != nil && ddd != nil)
+#

--- a/test/integration/IfStringToFloatStart/two variables.ts
+++ b/test/integration/IfStringToFloatStart/two variables.ts
@@ -1,0 +1,6 @@
+//
+let bbb: number = parseFloat(aaa);
+let ddd: number = parseFloat(ccc);
+
+if (!isNaN(bbb) && !isNaN(ddd)) {
+//


### PR DESCRIPTION
Provides a way to create a block in which code to run if given strings are successfully converted to floats as new variables.

Fixes #334.

Also found a sneaky bug around starting with a `"\n"` in `Command::addLineEnder`! Go figure.