### PR TITLE
Improved line component separation

### DIFF
--- a/src/Conversions/GlsParser.ts
+++ b/src/Conversions/GlsParser.ts
@@ -2,6 +2,7 @@ import { Command } from "../Commands/Command";
 import { CommandsBag } from "../Commands/CommandsBag";
 import { LineResults } from "../Commands/LineResults";
 import { CaseStyleConverterBag } from "./Casing/CaseStyleConverterBag";
+import { LineComponentSeparator } from "./LineComponentSeparator";
 import { ParametersValidator } from "./ParametersValidator";
 
 /**
@@ -19,6 +20,11 @@ export class GlsParser {
     private commandsBag: CommandsBag;
 
     /**
+     * Separates lines into their command names and parameters.
+     */
+    private lineComponentSeparator: LineComponentSeparator;
+
+    /**
      * Validates whether input parameters match command requirements.
      */
     private parametersValidator: ParametersValidator;
@@ -33,6 +39,7 @@ export class GlsParser {
         this.caseStyleConverterBag = caseStyleConverterBag;
         this.commandsBag = commandsBag;
         this.parametersValidator = new ParametersValidator();
+        this.lineComponentSeparator = new LineComponentSeparator();
     }
 
     /**
@@ -42,7 +49,7 @@ export class GlsParser {
      * @returns The equivalent line results.
      */
     public parseCommand(line: string): LineResults {
-        const parameters: string[] = this.separateLineComponents(line.trim());
+        const parameters: string[] = this.lineComponentSeparator.separate(line.trim());
 
         for (let i = 1; i < parameters.length; i += 1) {
             if (parameters[i][0] === "{") {
@@ -68,34 +75,6 @@ export class GlsParser {
     }
 
     /**
-     * Finds the corresponding end position for a starting separator.
-     *
-     * @param text   The String to search within.
-     * @param index   The starting location of the starting separator.
-     * @param starter   The starting separator, such as "{".
-     * @param ender   The ending separator, such as "}".
-     * @returns The position of the starter's corresponding ender.
-     */
-    private findSearchEnd(text: string, index: number, starter: string, ender: string): number {
-        let numStarts = 1;
-
-        for (let i: number = index + 1; i < text.length; i += 1) {
-            const current: string = text[i];
-
-            if (current === ender) {
-                numStarts -= 1;
-                if (numStarts === 0) {
-                    return i;
-                }
-            } else if (current === starter) {
-                numStarts += 1;
-            }
-        }
-
-        return -1;
-    }
-
-    /**
      * Parses a sub-command of GLS syntax from within a full line.
      *
      * @param section   A section of raw GLS syntax.
@@ -112,64 +91,6 @@ export class GlsParser {
         }
 
         return line;
-    }
-
-    /**
-     * Separates a line into its command name and parameters.
-     *
-     * @param line   A raw line of GLS syntax.
-     * @returns The line's command name, followed by any parameters.
-     * @remarks This assumes the line is already whitespace-trimmed.
-     */
-    private separateLineComponents(line: string): string[] {
-        const colonIndex: number = line.indexOf(":");
-        if (colonIndex === -1) {
-            return [line.trim()];
-        }
-
-        const output: string[] = [line.substring(0, colonIndex).trim()];
-
-        for (let i: number = colonIndex + 2; i < line.length; i += 1) {
-            let end: number;
-            let nextStart: number;
-
-            switch (line[i]) {
-                case "{":
-                    end = this.findSearchEnd(line, i, line[i], "}") + 1;
-                    if (end === 0) {
-                        throw new Error(`Could not find end for '{' starting at position ${i}.`);
-                    }
-
-                    nextStart = end;
-                    break;
-
-                case "(":
-                    end = this.findSearchEnd(line, i, line[i], ")");
-                    if (end === -1) {
-                        throw new Error(`Could not find end for '(' starting at position ${i}.`);
-                    }
-
-                    nextStart = end + 1;
-                    i += 1;
-                    break;
-
-                default:
-                    end = this.findSearchEnd(line, i, " ", " ");
-                    nextStart = end;
-            }
-
-            if (end === -1) {
-                end = nextStart = line.length;
-            }
-
-            if (i !== end) {
-                output.push(line.substring(i, end));
-            }
-
-            i = nextStart;
-        }
-
-        return output;
     }
 
     /**

--- a/src/Conversions/LineComponentSeparator.ts
+++ b/src/Conversions/LineComponentSeparator.ts
@@ -1,0 +1,91 @@
+
+/**
+ * Separates lines into their command names and parameters.
+ */
+export class LineComponentSeparator {
+    /**
+     * Separates a line into its command name and parameters.
+     *
+     * @param line   A raw line of GLS syntax.
+     * @returns The line's command name, followed by any parameters.
+     * @remarks This assumes the line is already whitespace-trimmed.
+     */
+    public separate(line: string): string[] {
+        const colonIndex: number = line.indexOf(":");
+        if (colonIndex === -1) {
+            return [line.trim()];
+        }
+
+        const output: string[] = [line.substring(0, colonIndex).trim()];
+
+        for (let i: number = colonIndex + 2; i < line.length; i += 1) {
+            let end: number;
+            let nextStart: number;
+
+            switch (line[i]) {
+                case "{":
+                    end = this.findSearchEnd(line, i, line[i], "}") + 1;
+                    if (end === 0) {
+                        throw new Error(`Could not find end for '{' starting at position ${i}.`);
+                    }
+
+                    nextStart = end;
+                    break;
+
+                case "(":
+                    end = this.findSearchEnd(line, i, line[i], ")");
+                    if (end === -1) {
+                        throw new Error(`Could not find end for '(' starting at position ${i}.`);
+                    }
+
+                    nextStart = end + 1;
+                    i += 1;
+                    break;
+
+                default:
+                    end = this.findSearchEnd(line, i, " ", " ");
+                    nextStart = end;
+            }
+
+            if (end === -1) {
+                end = nextStart = line.length;
+            }
+
+            if (i !== end) {
+                output.push(line.substring(i, end));
+            }
+
+            i = nextStart;
+        }
+
+        return output;
+    }
+
+    /**
+     * Finds the corresponding end position for a starting separator.
+     *
+     * @param text   The String to search within.
+     * @param index   The starting location of the starting separator.
+     * @param starter   The starting separator, such as "{".
+     * @param ender   The ending separator, such as "}".
+     * @returns The position of the starter's corresponding ender.
+     */
+    private findSearchEnd(text: string, index: number, starter: string, ender: string): number {
+        let numStarts = 1;
+
+        for (let i: number = index + 1; i < text.length; i += 1) {
+            const current: string = text[i];
+
+            if (current === ender) {
+                numStarts -= 1;
+                if (numStarts === 0) {
+                    return i;
+                }
+            } else if (current === starter) {
+                numStarts += 1;
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/Conversions/LineComponentSeparator.ts
+++ b/src/Conversions/LineComponentSeparator.ts
@@ -3,6 +3,8 @@
  * Separates lines into their command names and parameters.
  */
 export class LineComponentSeparator {
+    private static readonly quoteCharacters = new Set(["'", '"', "`"]);
+
     /**
      * Separates a line into its command name and parameters.
      *
@@ -42,6 +44,16 @@ export class LineComponentSeparator {
                     i += 1;
                     break;
 
+                case "\"":
+                    end = line.indexOf("\"", i);
+                    if (end === -1) {
+                        throw new Error(`Could not find end for '"' starting at position ${i}.`);
+                    }
+
+                    end += 1;
+                    nextStart = end;
+                    break;
+
                 default:
                     end = this.findSearchEnd(line, i, " ", " ");
                     nextStart = end;
@@ -72,17 +84,22 @@ export class LineComponentSeparator {
      */
     private findSearchEnd(text: string, index: number, starter: string, ender: string): number {
         let numStarts = 1;
+        let insideQuotes = false;
 
         for (let i: number = index + 1; i < text.length; i += 1) {
             const current: string = text[i];
 
-            if (current === ender) {
-                numStarts -= 1;
-                if (numStarts === 0) {
-                    return i;
+            if (LineComponentSeparator.quoteCharacters.has(current)) {
+                insideQuotes = !insideQuotes;
+            } else if (!insideQuotes) {
+                if (current === ender) {
+                    numStarts -= 1;
+                    if (numStarts === 0) {
+                        return i;
+                    }
+                } else if (current === starter) {
+                    numStarts += 1;
                 }
-            } else if (current === starter) {
-                numStarts += 1;
             }
         }
 

--- a/src/Conversions/LineComponentSeparator.ts
+++ b/src/Conversions/LineComponentSeparator.ts
@@ -45,7 +45,7 @@ export class LineComponentSeparator {
                     break;
 
                 case "\"":
-                    end = line.indexOf("\"", i);
+                    end = this.findSearchEndForQuotes(line, i);
                     if (end === -1) {
                         throw new Error(`Could not find end for '"' starting at position ${i}.`);
                     }
@@ -100,6 +100,25 @@ export class LineComponentSeparator {
                 } else if (current === starter) {
                     numStarts += 1;
                 }
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Finds the corresponding end position for a starting separator.
+     *
+     * @param text   The String to search within.
+     * @param index   The starting location of the starting separator.
+     * @param starter   The starting separator, such as "{".
+     * @param ender   The ending separator, such as "}".
+     * @returns The position of the starter's corresponding ender.
+     */
+    private findSearchEndForQuotes(text: string, index: number): number {
+        for (let i: number = index + 1; i < text.length; i += 1) {
+            if (text[i] === '"' && text[i - 1] !== "\\") {
+                return i;
             }
         }
 

--- a/test/unit/Conversions/LineComponentSeparatorTests.ts
+++ b/test/unit/Conversions/LineComponentSeparatorTests.ts
@@ -1,0 +1,69 @@
+import { expect } from "chai";
+import "mocha";
+
+import { LineComponentSeparator } from "../../../lib/Conversions/LineComponentSeparator";
+
+describe("LineComponentSeparator", () => {
+    describe("separate", () => {
+        const tests = [
+            {
+                description: "gives a command name when one is given without parameters",
+                input: "abc",
+                output: ["abc"]
+            },
+            {
+                description: "gives a command name and parameter when a command is given with a parameter",
+                input: "abc : def",
+                output: ["abc", "def"]
+            },
+            {
+                description: "gives a command name and two parameters when a command is given with two parameters",
+                input: "abc : def ghi",
+                output: ["abc", "def", "ghi"]
+            },
+            {
+                description: "separates a bracket recursion with a single internal command",
+                input: "abc : { def }",
+                output: ["abc", "{ def }"]
+            },
+            {
+                description: "separates a bracket recursion with an internal command and parameters",
+                input: "abc : { def : ghi jkl }",
+                output: ["abc", "{ def : ghi jkl }"]
+            },
+            {
+                description: "separates a bracket recursion with an internal command and parameters",
+                input: "abc : { def : ghi jkl }",
+                output: ["abc", "{ def : ghi jkl }"]
+            },
+            {
+                description: "separates a parenthesis recursion with internal parameters",
+                input: "abc : (def ghi)",
+                output: ["abc", "def ghi"]
+            },
+            {
+                description: "ignores brackets within quotes",
+                input: 'abc: "{ def : ghi }"',
+                output: ["abc", '"{ def : ghi }"']
+            },
+            {
+                description: "ignores brackets within nested quotes",
+                input: 'abc : { def ghi : jkl "{" mno }',
+                output: ["abc", '{ def ghi : jkl "{" mno }']
+            }
+        ];
+
+        for (const test of tests) {
+            it(test.description, () => {
+                // Arrange
+                const separator = new LineComponentSeparator();
+
+                // Act
+                const actual = separator.separate(test.input);
+
+                // Assert
+                expect(actual).to.be.deep.equal(test.output);
+            });
+        }
+    });
+});

--- a/test/unit/Conversions/LineComponentSeparatorTests.ts
+++ b/test/unit/Conversions/LineComponentSeparatorTests.ts
@@ -50,6 +50,11 @@ describe("LineComponentSeparator", () => {
                 description: "ignores brackets within nested quotes",
                 input: 'abc : { def ghi : jkl "{" mno }',
                 output: ["abc", '{ def ghi : jkl "{" mno }']
+            },
+            {
+                description: "ignores an escaped quote",
+                input: 'abc : "\""',
+                output: ["abc", '\""']
             }
         ];
 


### PR DESCRIPTION
Splits the logic for parsing a line into its immediate (non-recursive) sections into a new `LineComponentSeparator` class.

Fixes #408.