### PR TITLE
Generalized root/metadata files to allow languages to specify any amount

### DIFF
--- a/src/Rendering/Languages/CSharp.ts
+++ b/src/Rendering/Languages/CSharp.ts
@@ -63,22 +63,23 @@ export class CSharp extends Language {
      * @param projects   A property container for project-scale metadata.
      */
     protected generateProjectProperties(projects: ProjectProperties): void {
-        projects.fileFormat = [
-            `<?xml version="1.0"?>`,
-            `<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">`,
-            `  <metadata>`,
-            `    <id>{name}</id>`,
-            `    <title>{name}</title>`,
-            `    <version>{version}</version>`,
-            `    <licenseUrl>{url}/blob/master/LICENSE.md</licenseUrl>`,
-            `    <projectUrl>{url}</projectUrl>`,
-            `    <description>`,
-            `      {description}`,
-            `    </description>`,
-            `  </metadata>`,
-            `</package>`,
-        ];
-        projects.fileName = "{name}.nuspec";
+        projects.metadataFiles = {
+            "{name}.nuspec": [
+                `<?xml version="1.0"?>`,
+                `<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">`,
+                `  <metadata>`,
+                `    <id>{name}</id>`,
+                `    <title>{name}</title>`,
+                `    <version>{version}</version>`,
+                `    <licenseUrl>{url}/blob/master/LICENSE.md</licenseUrl>`,
+                `    <projectUrl>{url}</projectUrl>`,
+                `    <description>`,
+                `      {description}`,
+                `    </description>`,
+                `  </metadata>`,
+                `</package>`,
+            ],
+        };
         projects.nameFormat = CaseStyle.PackageUpperCase;
     }
 

--- a/src/Rendering/Languages/Java.ts
+++ b/src/Rendering/Languages/Java.ts
@@ -53,24 +53,25 @@ export class Java extends Language {
      * @param projects   A property container for project-scale metadata.
      */
     protected generateProjectProperties(projects: ProjectProperties): void {
-        projects.fileFormat = [
-            `<?xml version="1.0" encoding="UTF-8"?>`,
-            `<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">`,
-            `    <modelVersion>4.0.0</modelVersion>`,
-            ``,
-            `    <licenses>`,
-            `        <license>`,
-            `            <name>{license}</name>`,
-            `            <distribution>repo</distribution>`,
-            `        </license>`,
-            `    </licenses>`,
-            ``,
-            `    <scm>`,
-            `        <url>{url}</url>`,
-            `    </scm>`,
-            `</project>`,
-        ];
-        projects.fileName = "pom.xml";
+        projects.metadataFiles = {
+            "pom.xml": [
+                `<?xml version="1.0" encoding="UTF-8"?>`,
+                `<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">`,
+                `    <modelVersion>4.0.0</modelVersion>`,
+                ``,
+                `    <licenses>`,
+                `        <license>`,
+                `            <name>{license}</name>`,
+                `            <distribution>repo</distribution>`,
+                `        </license>`,
+                `    </licenses>`,
+                ``,
+                `    <scm>`,
+                `        <url>{url}</url>`,
+                `    </scm>`,
+                `</project>`,
+            ],
+        };
         projects.nameFormat = CaseStyle.PackageLowerCase;
     }
 

--- a/src/Rendering/Languages/JavaScript.ts
+++ b/src/Rendering/Languages/JavaScript.ts
@@ -61,28 +61,30 @@ export class JavaScript extends Language {
      * @param projects   A property container for project-scale metadata.
      */
     protected generateProjectProperties(projects: ProjectProperties): void {
-        projects.fileFormat = [
-            `{`,
-            `    "name": "{name}",`,
-            `    "author": {`,
-            `        "name": "{author.name}",`,
-            `        "email": "{author.email}"`,
-            `    },`,
-            `    "bugs": {`,
-            `        "url": "{repository.url}/issues"`,
-            `    },`,
-            `    "description": "{description}",`,
-            `    "license": "{license}",`,
-            `    "repository": {`,
-            `        "type": "{repository.type}",`,
-            `        "url": "{repository.url}"`,
-            `    },`,
-            `    "main": "{main}.js",`,
-            `    "typings": "{typings}.d.ts",`,
-            `    "version": "{version}"`,
-            `}`,
-        ];
-        projects.fileName = "package.json";
+        projects.metadataFiles = {
+            "package.json": [
+                `{`,
+                `    "name": "{name}",`,
+                `    "author": {`,
+                `        "name": "{author.name}",`,
+                `        "email": "{author.email}"`,
+                `    },`,
+                `    "bugs": {`,
+                `        "url": "{repository.url}/issues"`,
+                `    },`,
+                `    "description": "{description}",`,
+                `    "license": "{license}",`,
+                `    "repository": {`,
+                `        "type": "{repository.type}",`,
+                `        "url": "{repository.url}"`,
+                `    },`,
+                `    "main": "{main}.js",`,
+                `    "typings": "{typings}.d.ts",`,
+                `    "version": "{version}"`,
+                `}`,
+            ],
+            "src/index.js": [`{{#exports}}`, `export \\{{name}\\} from "{file}";`, `{{/exports}}`],
+        };
         projects.nameFormat = CaseStyle.DashLowerCase;
     }
 

--- a/src/Rendering/Languages/Properties/ProjectProperties.ts
+++ b/src/Rendering/Languages/Properties/ProjectProperties.ts
@@ -22,7 +22,7 @@ export interface IGlsProjectMetadata {
     license: string;
 
     /**
-     * UpperCamelCase name of the project with periods between words.
+     * Package.Upper.Case name of the project.
      */
     name: string;
 
@@ -47,17 +47,12 @@ export interface IGlsProjectMetadata {
  */
 export class ProjectProperties {
     /**
-     * Lines of text in the root project file name.
+     * Lines of text in each generated root file, keyed by name.
      */
-    public fileFormat: string[];
+    public metadataFiles: { [i: string]: string[] };
 
     /**
-     * Root file name storing project metadata fields.
-     */
-    public fileName: string;
-
-    /**
-     * How to represent the name in project metadata.
+     * How to represent a project's name in metadata files.
      */
     public nameFormat: CaseStyle;
 }

--- a/src/Rendering/Languages/Python.ts
+++ b/src/Rendering/Languages/Python.ts
@@ -63,8 +63,7 @@ export class Python extends Language {
      * @param projects   A property container for project-scale metadata.
      */
     protected generateProjectProperties(projects: ProjectProperties): void {
-        projects.fileFormat = [`{name}`];
-        projects.fileName = "requirements.txt";
+        projects.metadataFiles = {};
         projects.nameFormat = CaseStyle.DashLowerCase;
     }
 

--- a/src/Rendering/Languages/Ruby.ts
+++ b/src/Rendering/Languages/Ruby.ts
@@ -61,8 +61,29 @@ export class Ruby extends Language {
      * @param projects   A property container for project-scale metadata.
      */
     protected generateProjectProperties(projects: ProjectProperties): void {
-        projects.fileFormat = [`source "https://rubygems.org"`];
-        projects.fileName = "Gemfile";
+        projects.metadataFiles = {
+            Gemfile: [`source "https://rubygems.org"`, ``, `gemspec`],
+            "{name}.gemspec": [
+                `# encoding: utf-8`,
+                ``,
+                `Gem::Specification.new do |spec|`,
+                `    spec.author = ["{author}"]`,
+                `    spec.description = "{description}"`,
+                `    spec.email = "{email}"`,
+                `    spec.files = Dir[`,
+                `        *.md,`,
+                `        {{#exports}},`,
+                `        {file}`,
+                `        {{/exports}},`,
+                `    ]`,
+                `    spec.homepage = "{homepage}"`,
+                `    spec.license = "{license}"`,
+                `    spec.name = "{name}"`,
+                `    spec.summary = spec.description`,
+                `    spec.version = "{version}"`,
+                ``,
+            ],
+        };
         projects.nameFormat = CaseStyle.DashLowerCase;
     }
 

--- a/src/Rendering/Languages/TypeScript.ts
+++ b/src/Rendering/Languages/TypeScript.ts
@@ -61,28 +61,30 @@ export class TypeScript extends Language {
      * @param projects   A property container for project-scale metadata.
      */
     protected generateProjectProperties(projects: ProjectProperties): void {
-        projects.fileFormat = [
-            `{`,
-            `    "name": "{name}",`,
-            `    "author": {`,
-            `        "name": "{authorName}",`,
-            `        "email": "{authorEmail}"`,
-            `    },`,
-            `    "bugs": {`,
-            `        "url": "{url}/issues"`,
-            `    },`,
-            `    "description": "{description}",`,
-            `    "license": "{license}",`,
-            `    "repository": {`,
-            `        "type": "{repositoryType}",`,
-            `        "url": "{url}"`,
-            `    },`,
-            `    "main": "{main}.js",`,
-            `    "typings": "{typings}.d.ts",`,
-            `    "version": "{version}"`,
-            `}`,
-        ];
-        projects.fileName = "package.json";
+        projects.metadataFiles = {
+            "package.json": [
+                `{`,
+                `    "name": "{name}",`,
+                `    "author": {`,
+                `        "name": "{author.name}",`,
+                `        "email": "{author.email}"`,
+                `    },`,
+                `    "bugs": {`,
+                `        "url": "{repository.url}/issues"`,
+                `    },`,
+                `    "description": "{description}",`,
+                `    "license": "{license}",`,
+                `    "repository": {`,
+                `        "type": "{repository.type}",`,
+                `        "url": "{repository.url}"`,
+                `    },`,
+                `    "main": "{main}.js",`,
+                `    "typings": "{typings}.d.ts",`,
+                `    "version": "{version}"`,
+                `}`,
+            ],
+            "src/index.ts": [`{{#exports}}`, `export \\{ {name} \\} from "{file}";`, `{{/exports}}`],
+        };
         projects.nameFormat = CaseStyle.DashLowerCase;
     }
 


### PR DESCRIPTION
Some languages, such as JavaScript and Ruby, require multiple root files. Instead of having specific booleans and formats for each, this just lets languages specify a map.

Progress on #469 