### PR TITLE
Stopped adding indentation for abstract member function declarations

### DIFF
--- a/src/Rendering/Commands/MemberFunctionDeclareAbstractCommand.ts
+++ b/src/Rendering/Commands/MemberFunctionDeclareAbstractCommand.ts
@@ -15,7 +15,6 @@ export class MemberFunctionDeclareAbstractCommand extends MemberFunctionDeclareC
      */
     private static metadata: CommandMetadata = new CommandMetadata(CommandNames.MemberFunctionDeclareAbstract)
         .withDescription("Declares an abstract member function")
-        .withIndentation([0])
         .withParameters([
             new KeywordParameter(KeywordNames.PrivaciesAbstract, "The privacy of the function.", true),
             new SingleParameter("name", "The name of the function.", true),
@@ -56,5 +55,12 @@ export class MemberFunctionDeclareAbstractCommand extends MemberFunctionDeclareC
      */
     protected getEnder(): string {
         return this.language.syntax.style.semicolon;
+    }
+
+    /**
+     * @returns How much indentation to add after the last command line.
+     */
+    protected getIndentation(): number {
+        return 0;
     }
 }

--- a/src/Rendering/Commands/MemberFunctionDeclareCommand.ts
+++ b/src/Rendering/Commands/MemberFunctionDeclareCommand.ts
@@ -54,7 +54,7 @@ export abstract class MemberFunctionDeclareCommand extends Command {
         }
 
         output = [new CommandResult(declaration, 0)];
-        this.addLineEnder(output, this.getEnder(), 1);
+        this.addLineEnder(output, this.getEnder(), this.getIndentation());
 
         return new LineResults(output, false);
     }
@@ -73,6 +73,11 @@ export abstract class MemberFunctionDeclareCommand extends Command {
      * @returns Text to end the declaration.
      */
     protected abstract getEnder(): string;
+
+    /**
+     * @returns How much indentation to add after the last command line.
+     */
+    protected abstract getIndentation(): number;
 
     /**
      * Generates a string for a parameter.

--- a/src/Rendering/Commands/MemberFunctionDeclareStartCommand.ts
+++ b/src/Rendering/Commands/MemberFunctionDeclareStartCommand.ts
@@ -57,4 +57,11 @@ export class MemberFunctionDeclareStartCommand extends MemberFunctionDeclareComm
     protected getEnder(): string {
         return this.language.syntax.functions.defineStartRight;
     }
+
+    /**
+     * @returns How much indentation to add after the last command line.
+     */
+    protected getIndentation(): number {
+        return 1;
+    }
 }


### PR DESCRIPTION
Fixes #484.