### PR TITLE
Docs cleanup: standalone functions; docs linting

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -3,5 +3,6 @@
     "line-length": {
         "line_length": 280
     },
-    "no-inline-html": false
+    "no-inline-html": false,
+    "no-trailing-punctuation": false
 }

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 [![Greenkeeper badge](https://badges.greenkeeper.io/general-language-syntax/GLS.svg)](https://greenkeeper.io/)
 
 A unified syntax that compiles into a number of OOP languages.
+
 * Read the docs at **[glslang.org](https://glslang.org)**.
 * Try it at **[aka.ms/gls-demo](https://aka.ms/gls-demo)**.
 
-***GLS is still under development. Don't expect everything to work!***
-
+> **GLS is still under development. Don't expect everything to work!**
 
 ## Usage
 
@@ -34,12 +34,11 @@ See [gls-cli](https://github.com/HighSchoolHacking/gls-cli).
 ```javascript
 import { Gls } from "general-language-syntax";
 
-const gls = new Gls("CSharp");
+const gls = new Gls("C#");
 
 // System.Console.WriteLine("Hello world!");
 gls.convert([`print : ("Hello world!")`]);
 ```
-
 
 ## Status
 
@@ -95,10 +94,8 @@ GLS is just shy of **0.4**.
     </tbody>
 </table>
 
-
 ## Development
 
 If you'd like to contribute to GLS, see [Development.md](https://github.com/general-language-syntax/GLS/blob/master/docs/development.md).
 
-_Requires Node >=8_
-
+> Requires Node >=8

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -22,4 +22,5 @@
   * [Unsupported Commands](docs/syntax/unsupported-commands.md)
 * [Projects](docs/projects.md)
 * [Internals](docs/internals.md)
+* [Languages](docs/languages.md)
 * [Omissions](docs/omissions.md)

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -74,11 +74,6 @@ These languages each need to be investigated and assigned a higher tier.
 
 ## Unsupported
 
-Some languages will enver be able to be accurately compiled to by GLS because of severe structural abnormalities in the language's design.
-These languages are so different from the norm that any attempt to output them from GLS would be horrendously overcomplicated and inaccurate.
-
-These languages will never be output by GLS for the following common reasons _(among others)_:
-
 <table>
     <thead>
         <th>Language</th>
@@ -101,6 +96,11 @@ These languages will never be output by GLS for the following common reasons _(a
         <td>✓</td>
     </tr>
 </table>
+
+Some languages will enver be able to be accurately compiled to by GLS because of severe structural abnormalities in the language's design.
+These languages are so different from the norm that any attempt to output them from GLS would be horrendously overcomplicated and inaccurate.
+
+These languages will never be output by GLS for the following common reasons _(among others)_:
 
 ## Best Guess
 
@@ -129,8 +129,6 @@ For example, when using GLS for snippets of code as sample answer guidelines to 
 
 ## Output Only
 
-These languages can be fully output by GLS but don't provide rich enough type information in their syntax to be statically converted to GLS.
-
 <table>
     <thead>
         <th>Language</th>
@@ -148,10 +146,9 @@ These languages can be fully output by GLS but don't provide rich enough type in
     </tbody>
 </table>
 
-## Partial Input
+These languages can be fully output by GLS but don't provide rich enough type information in their syntax to be statically converted to GLS.
 
-These languages may be generally compiled from their native source code to GLS with a "best guess" approximation of the equivalent GLS code.
-They must have some kind of gradual or even static typing, but are not required to fully support differences between all GLS types.
+## Partial Input
 
 <table>
     <thead>
@@ -170,14 +167,10 @@ They must have some kind of gradual or even static typing, but are not required 
     </tbody>
 </table>
 
+These languages may be generally compiled from their native source code to GLS with a "best guess" approximation of the equivalent GLS code.
+They must have some kind of gradual or even static typing, but are not required to fully support differences between all GLS types.
+
 ## Full
-
-These languages are capable of being compiled from their native source code to GLS and then back out to any supported language.
-
-In order for a language to be fully supported, it must:
-
-* Completely support static typings via a programmable AST.
-* Recognize differences between all GLS types, including `int` vs. `float`.
 
 <table>
     <thead>
@@ -194,4 +187,9 @@ In order for a language to be fully supported, it must:
     </tr>
 </table>
 
-language / compiler / comments
+These languages are capable of being compiled from their native source code to GLS and then back out to any supported language.
+
+In order for a language to be fully supported, it must:
+
+* Completely support static typings via a programmable AST.
+* Recognize differences between all GLS types, including `int` vs. `float`.

--- a/docs/languages.md
+++ b/docs/languages.md
@@ -1,0 +1,197 @@
+# Languages
+
+There are six "tiers" of langauges recognized by GLS:
+
+1. [Unknown](#unknown)
+2. [Unsupported](#unsupported)
+3. [Best Guess](#best%20guess)
+4. [Output Only](#output%20only)
+5. [Partial Input](#partial%20input)
+6. [Full](#full)
+
+## Unknown
+
+These languages each need to be investigated and assigned a higher tier.
+
+<table>
+    <thead>
+        <th>Language</th>
+        <th>Issue</th>
+    </thead>
+    <tr>
+        <th>D</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/361">#361</a></td>
+    </tr>
+    <tr>
+        <th>emojicode</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/429">#429</a></td>
+    </tr>
+    <tr>
+        <th>Groovy</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/454">#454</a></td>
+    </tr>
+    <tr>
+        <th>Haxe</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/247">#247</a></td>
+    </tr>
+    <tr>
+        <th>Kotlin</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/453">#453</a></td>
+    </tr>
+    <tr>
+        <th>LLVM</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/381">#381</a></td>
+    </tr>
+    <tr>
+        <th>LOLCODE</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/267">#267</a></td>
+    </tr>
+    <tr>
+        <th>Objective C</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/191">#191</a></td>
+    </tr>
+    <tr>
+        <th>PHP</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/102">#102</a></td>
+    </tr>
+    <tr>
+        <th>Powershell</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/103">#103</a></td>
+    </tr>
+    <tr>
+        <th>sh</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/436">#436</a></td>
+    </tr>
+    <tr>
+        <th>Swift</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/105">#105</a></td>
+    </tr>
+    <tr>
+        <th>Visual Basic</th>
+        <td><a href="https://github.com/general-language-syntax/GLS/issues/439">#439</a></td>
+    </tr>
+</table>
+
+## Unsupported
+
+Some languages will enver be able to be accurately compiled to by GLS because of severe structural abnormalities in the language's design.
+These languages are so different from the norm that any attempt to output them from GLS would be horrendously overcomplicated and inaccurate.
+
+These languages will never be output by GLS for the following common reasons _(among others)_:
+
+<table>
+    <thead>
+        <th>Language</th>
+        <th>Unusual Classes</th>
+        <th>Unusual Returns</th>
+    </thead>
+    <tr>
+        <th>C</th>
+        <td>✓</td>
+        <td></td>
+    </tr>
+    <tr>
+        <th>Go</th>
+        <td>✓</td>
+        <td></td>
+    </tr>
+    <tr>
+        <th>Matlab</th>
+        <td></td>
+        <td>✓</td>
+    </tr>
+</table>
+
+## Best Guess
+
+Some languages will never be able to be accurately compiled to by GLS, but the compiler can roughly come close.
+
+These languages will never be guaranteed accurate GLS output for the following common reasons _(among others)_:
+
+<table>
+    <thead>
+        <th>Language</th>
+        <th>Manual Pointers</th>
+    </thead>
+    <tr>
+        <th>C++</th>
+        <td>✓</td>
+    </tr>
+</table>
+
+### Why Try?
+
+There are still some cases where it may be useful to have near-working output in an unsupported language.
+For example, when using GLS for snippets of code as sample answer guidelines to coding interview questions, it's not necessary for the result to be provably correct.
+
+> Again: GLS gives no guarantee of code working in these languages.
+> They will almost certainly fail at more than a few lines.
+
+## Output Only
+
+These languages can be fully output by GLS but don't provide rich enough type information in their syntax to be statically converted to GLS.
+
+<table>
+    <thead>
+        <th>Language</th>
+    </thead>
+    <tbody>
+        <tr>
+            <th>JavaScript</th>
+        </tr>
+        <tr>
+            <th>Ruby</th>
+        </tr>
+        <tr>
+            <th>Python</th>
+        </tr>
+    </tbody>
+</table>
+
+## Partial Input
+
+These languages may be generally compiled from their native source code to GLS with a "best guess" approximation of the equivalent GLS code.
+They must have some kind of gradual or even static typing, but are not required to fully support differences between all GLS types.
+
+<table>
+    <thead>
+        <th>Language</th>
+        <th>Compiler</th>
+        <th>
+            <code>int</code> vs <code>float</code>
+        </th>
+    </thead>
+    <tbody>
+        <tr>
+            <th>TypeScript</th>
+            <td><a href="https://github.com/general-language-syntax/TS-GLS">TS-GLS</a></td>
+            <td><em>Missing</em></td>
+        </tr>
+    </tbody>
+</table>
+
+## Full
+
+These languages are capable of being compiled from their native source code to GLS and then back out to any supported language.
+
+In order for a language to be fully supported, it must:
+
+* Completely support static typings via a programmable AST.
+* Recognize differences between all GLS types, including `int` vs. `float`.
+
+<table>
+    <thead>
+        <th>Language</th>
+        <th>Compiler</th>
+    </thead>
+    <tr>
+        <th>C#</th>
+        <td><a href="https://github.com/general-language-syntax/CS-GLS">CS-GLS</a></td>
+    </tr>
+    <tr>
+        <th>Java</th>
+        <td><em>(not started)</em></td>
+    </tr>
+</table>
+
+language / compiler / comments

--- a/docs/omissions.md
+++ b/docs/omissions.md
@@ -6,30 +6,97 @@ GLS intentionally targets a "lowest common denominator" of features for common O
 
 If any target language doesn't reasonably support a feature, GLS cannot support that feature.
 
-| Feature | C# | Java | JavaScript | Python | Ruby | TypeScript |
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-| async/await |  | _Missing_ |  |  | _Missing_ |  |
-| Default Member Variable Values |  |  |  |  | _Missing_ |  |
-| Do/While Loops |  |  |  | _Missing_ |  |  |
-| Enums Without Values |  |  |  |  | _Missing_ |  |
-| Multiline Lambdas |  |  |  | _Missing_ |  |  |
-| Optional Parameters |  | _Missing_ |  |  |  |  |
-| Overloaded Functions |  |  | _Missing_ | _Missing_ | _Missing_ | _Missing_ |
-| String.Replace |  |  | _Abnormal_ |  |  | _Abnormal_ |
-| Switch Statements |  |  |  | _Missing_ |  |  |
-
-## Intentionally Unsupported Languages
-
-Not all languages work similarly to the supported ones.
-These will likely never receive GLS support, for the following common reasons (among others):
-
-| Language | Manual Pointers | Pass-By-Value | Unusual Classes | Unusual Returns |
-| :--- | :--- | :--- | :--- | :--- |
-| C | ✓ | ✓ | ✓ |  |
-| C++ | ✓ |  |  |  |
-| Go |  |  | ✓ |  |
-| Matlab |  |  |  | ✓ |
-| R |  | ✓ |  |  |
-| Rust | ✓ |  |  |  |
-
-This list will grow as languages are requested.
+<table>
+    <thead>
+        <th>Feature</th>
+        <th>C#</th>
+        <th>Java</th>
+        <th>JavaScript</th>
+        <th>Python</th>
+        <th>Ruby</th>
+        <th>TypeScript</th>
+    </thead>
+    <tbody>
+        <tr>
+            <th>async/await</th>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>Default Member Variable Values</th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>Do/While Loops</th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>Enums Without Values</th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>Multiline Lambdas</th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>Optional Parameters</th>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+        </tr>
+        <tr>
+            <th>Optional Parameters</th>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td><em>Missing</em></td>
+            <td><em>Missing</em></td>
+            <td><em>Missing</em></td>
+        </tr>
+        <tr>
+            <th>Optional Parameters</th>
+            <td></td>
+            <td></td>
+            <td><em>Abnormal</em></td>
+            <td></td>
+            <td></td>
+            <td><em>Abnormal</em></td>
+        </tr>
+        <tr>
+            <th>Switch Statements</th>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><em>Missing</em></td>
+            <td></td>
+            <td></td>
+        </tr>
+    </tbody>
+</table>

--- a/docs/syntax/arrays-and-lists.md
+++ b/docs/syntax/arrays-and-lists.md
@@ -7,15 +7,6 @@ Although some output languages don't consider there to be a difference between a
 
 GLS considers the two to be two different data structures and has mostly separate commands for each.
 
-The only shared command between the two is `index`, which takes in a name of a container and an integer index.
-
-```gls
-index : container 1
-```
-
-* In C#: `container[1]`
-* In Python: `container[1]`
-
 ## Arrays
 
 Because arrays are fixed-length, there are very few operations available on them.
@@ -23,13 +14,22 @@ Because arrays are fixed-length, there are very few operations available on them
 Create new arrays with `array initialize`, which takes in the type of array and any number of initial items in the array.
 For variables, declare the type of the array with `array type`, which takes in the type of the array.
 
+Retrieve a single member of an array with `array index`, which takes in a name of a container and an integer index.
+
+```gls
+array index : container 1
+```
+
+* In C#: `container[1]`
+* In Python: `container[1]`
+
 Get the length of an array with `array length`, which takes in a name of an array.
 
 ```gls
 variable : fruits { array type : string } { array initialize : string "apple" "banana" "cherry" }
 
 print : { string format : ("There are {0} fruits.") { array length : fruits } int }
-print : { string format : ("The first fruit is {0}.") { index : fruits 0 } string }
+print : { string format : ("The first fruit is {0}.") { array index : fruits 0 } string }
 ```
 
 In C#:
@@ -55,6 +55,15 @@ print("The first fruit is {0}.".format(fruits[0]))
 GLS lists are much more flexible than arrays.
 They can be dynamically resized, added onto one another, and sort _\(for primitive types\)_.
 
+Retrieve a single member of a list with `list index`, which takes in a name of a container and an integer index.
+
+```gls
+list index : container 1
+```
+
+* In C#: `container[1]`
+* In Python: `container[1]`
+
 Similar to arrays, create a new list with `list initialize`, declare a list type with `list type`, and get a list's length with `list length`.
 Add a single item to a list with `list pop`, which takes in a name of a list and a new item, or add a full list to another list with `list add list`, which takes in the name of an existing list and a second list to add to the existing list.
 
@@ -65,8 +74,8 @@ list push : fruits "dragonberry"
 list add list : fruits { list initialize : string "elderberry" "fig" }
 
 print : { string format : ("There are {0} fruits.") { list length : fruits } int }
-print : { string format : ("The first fruit is {0}.") { index : fruits 0 } string }
-print : { string format : ("The last fruit is {0}.") { index : fruits { operation : { list length : fruits } minus 1 } } string }
+print : { string format : ("The first fruit is {0}.") { list index : fruits 0 } string }
+print : { string format : ("The last fruit is {0}.") { list index : fruits { operation : { list length : fruits } minus 1 } } string }
 ```
 
 In C#:

--- a/docs/syntax/classes/member-functions.md
+++ b/docs/syntax/classes/member-functions.md
@@ -13,7 +13,7 @@ class start : Announcer
         print : { concatenate : { member variable : private { this } greeting } ", " name "!" }
     member function declare end
 
-    constructor start : Announcer greeting string
+    constructor start : public Announcer greeting string
         operation : { member variable : private { this } greeting } equals greeting
     constructor end
 class end

--- a/docs/syntax/classes/member-variables.md
+++ b/docs/syntax/classes/member-variables.md
@@ -15,9 +15,9 @@ class start : Person
     member variable declare : private name string
     member variable declare : private age float
 
-    constructor start : Person name string age float
+    constructor start : public Person name string age float
         operation : { member variable : private { this } name } equals name
-        operation : { member variable : private { this } age} equals age
+        operation : { member variable : private { this } age } equals age
     constructor end
 class end
 ```

--- a/docs/syntax/development.md
+++ b/docs/syntax/development.md
@@ -48,8 +48,8 @@ You can run specific suites of tests using `npm run test:integration` or `npm ru
 You can run a subset of commands in either by passing `--command`:
 
 ```shell
-npm run test:integration --command *string*
-npm run test:end-to-end --command StringFormat
+npm run test:run:integration --command *string*
+npm run test:run:end-to-end --command StringFormat
 ```
 
 When adding a new command, _always_ add new integration tests for it.

--- a/docs/syntax/dictionaries.md
+++ b/docs/syntax/dictionaries.md
@@ -3,13 +3,13 @@
 The concept of a data structure with mapped keys to values changes drastically across output languages.
 All support some form of creating a dictionary and getting or setting values in it.
 
-Create a new dictionary with `dictionary new`, which takes in the key and value types of the dictionary.
-Accessing members is still done with `index` and setting is still done with with `operation`.
+Create a new dictionary with `dictionary initialize`, which takes in the key and value types of the dictionary.
+Accessing members is done with `dictionary index` and setting is still done with with `operation`.
 
 ```gls
-variable : counts { dictionary type : string int } { dictionary new : string int }
-operation : { index : counts "apple" } equals 3
-operation : { index : counts "banana" } equals 2
+variable : counts { dictionary type : string int } { dictionary initialize : string int }
+operation : { dictionary index : counts "apple" } equals 3
+operation : { dictionary index : counts "banana" } equals 2
 ```
 
 In C#:
@@ -28,14 +28,14 @@ counts["apple"] = 3
 counts["banana"] = 2
 ```
 
-Alternately, create a multi-line initialization with `dictionary new start`, which is otherwise identical, and `dictionary new end`.
+Alternately, create a multi-line initialization with `dictionary initialize start`, which is otherwise identical, and `dictionary initialize end`.
 Describe each pair of initial values inside with `dictionary pair`, which takes in the key type, value type, and a `,` if it isn't the last pair of initialization.
 
 ```gls
-variable start : counts { dictionary type : string int } { dictionary new start : string int }
+variable start : counts { dictionary type : string int } { dictionary initialize start : string int }
     dictionary pair : "apple" 3 ,
     dictionary pair : "banana" 2
-dictionary new end
+dictionary initialize end
 ```
 
 In C#:

--- a/docs/syntax/standalone-functions.md
+++ b/docs/syntax/standalone-functions.md
@@ -22,7 +22,7 @@ Calling standalone functions with `standalone function` takes in the name of the
 ```gls
 standalone functions declare start : export TextUtilities
     standalone function declare start : public SquareText string text string
-        return : { standalone function : TextUtilities private RepeatText text { string length : text } }
+        return : { standalone function : private TextUtilities RepeatText text { string length : text } }
     standalone function declare end
 
     standalone function declare start : private RepeatText string text string times int
@@ -33,7 +33,7 @@ standalone functions declare start : export TextUtilities
         for numbers end
 
         return : combined
-    standalone function end
+    standalone function declare end
 standalone functions declare end
 ```
 
@@ -85,7 +85,7 @@ It takes in the name of the group in PascalCase followed by any number of standa
 ```gls
 import local : Utilities Text use { import standalone functions : TextUtilities RepeatText }
 
-variable : repeated string { standalone function : TextUtilities public RepeatText "foo" 7 }
+variable : repeated string { standalone function : public TextUtilities RepeatText "foo" 7 }
 ```
 
 In C#:

--- a/docs/syntax/standalone-functions/main.md
+++ b/docs/syntax/standalone-functions/main.md
@@ -5,8 +5,8 @@ All languages provide some way to execute code immediately.
 Scripting languages such as Python and Ruby will execute all code in order immediately,
 whereas class-based languages such as C# and Java require a class wrapping a static method akin to C/C++'s "main" function.
 
-GLS resolves the differences by declaring an area as a "main context".
-A main function may be declared within that context.
+GLS resolves the differences by declaring an area as a "main context" with `main context start` and `main context end`.
+A main function may be declared within that context with `main start` and `main end`.
 
 ```gls
 main context start
@@ -40,11 +40,11 @@ if __name__ == "__main__":
 ## Functions
 
 Main contexts, other than the way they're declared, are functionally identically to standalone function groups.
-Use the `main group` command to refer to the group name.
+That means you can still declare standalone functions within them.
 
 ```gls
 main context start
-    standalone function declare start : private { main group } SayHello void name string
+    standalone function declare start : private SayHello void name string
         print : { concatenate : ("Hello, ") name "!" }
     standalone function declare end
 
@@ -61,7 +61,7 @@ using System;
 
 class Program
 {
-    void SayHello(string name)
+    private void SayHello(string name)
     {
         Console.WriteLine("Hello, " + name + "!");
     }

--- a/docs/syntax/strings.md
+++ b/docs/syntax/strings.md
@@ -26,8 +26,8 @@ Format strings are string literals with any number of bracket-surrounded numbers
 variable : foo string "foo"
 variable : bar int 7
 
-string format : ("Foo: {0}") foo
-string format : ("Foo: {0}; Bar: {1}") foo bar
+string format : ("Foo: {0}") foo string
+string format : ("Foo: {0}; Bar: {1}") foo string bar int
 ```
 
 In C#:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
         "url": "ssh://git@github.com:general-language-syntax/GLS.git"
     },
     "scripts": {
-        "docs": "npm run docs:refresh-docs && npm run docs:markdownlint",
+        "docs": "npm run docs:refresh-docs && npm run docs:gls && npm run docs:markdownlint",
+        "docs:gls": "node util/docs/compileGls.js",
         "docs:markdownlint": "markdownlint --config .markdownlint.json --ignore docs/commands/**/*.md --rules ./node_modules/sentences-per-line/index.js docs/**/*.md",
         "docs:refresh-docs": "node util/docs/refresh.js",
         "precommit": "pretty-quick --staged --write",

--- a/src/Rendering/Commands/CommandsBagFactory.ts
+++ b/src/Rendering/Commands/CommandsBagFactory.ts
@@ -52,6 +52,7 @@ import { IfStringToFloatEndCommand } from "./IfStringToFloatEndCommand";
 import { IfStringToFloatStartCommand } from "./IfStringToFloatStartCommand";
 import { ImportLocalCommand } from "./ImportLocalCommand";
 import { ImportPackageCommand } from "./ImportPackageCommand";
+import { ImportStandaloneFunctionsCommand } from "./ImportStandaloneFunctionsCommand";
 import { InstanceOfCommand } from "./InstanceOfCommand";
 import { InterfaceEndCommand } from "./InterfaceEndCommand";
 import { InterfaceMethodCommand } from "./InterfaceMethodCommand";
@@ -199,6 +200,7 @@ export class CommandsBagFactory {
             new IfStringToFloatStartCommand(context),
             new ImportLocalCommand(context),
             new ImportPackageCommand(context),
+            new ImportStandaloneFunctionsCommand(context),
             new InstanceOfCommand(context),
             new InterfaceEndCommand(context),
             new InterfaceMethodCommand(context),

--- a/src/Rendering/Commands/ImportCommand.ts
+++ b/src/Rendering/Commands/ImportCommand.ts
@@ -39,15 +39,15 @@ export abstract class ImportCommand extends Command {
             throw new Error('A "use" parameter must be in import commands.');
         }
 
-        const lineResults = new LineResults([], false);
-        let packagePath: string[] = parameters.slice(1, usingSplit);
         const items: string[] = parameters.slice(usingSplit + 1);
         const relativity: ImportRelativity = this.getRelativity();
+        let packagePath: string[] = parameters.slice(1, usingSplit);
 
         if (relativity === ImportRelativity.Local) {
             packagePath = ImportCommand.pathResolver.resolve(this.context.getDirectoryPath(), packagePath);
         }
 
+        const lineResults = new LineResults([], false);
         lineResults.addImports([new Import(packagePath, items, this.getRelativity())]);
 
         return lineResults;

--- a/src/Rendering/Commands/ImportStandaloneFunctionsCommand.ts
+++ b/src/Rendering/Commands/ImportStandaloneFunctionsCommand.ts
@@ -1,0 +1,60 @@
+import { LineResults } from "../LineResults";
+import { CommandNames } from "../Names/CommandNames";
+import { Command } from "./Command";
+import { CommandMetadata } from "./Metadata/CommandMetadata";
+import { RepeatingParameters } from "./Metadata/Parameters/RepeatingParameters";
+import { SingleParameter } from "./Metadata/Parameters/SingleParameter";
+
+/**
+ * Resolves standalone functions or their class for an import.
+ */
+export class ImportStandaloneFunctionsCommand extends Command {
+    /**
+     * Metadata on the command.
+     */
+    private static metadata: CommandMetadata = new CommandMetadata(CommandNames.ImportStandaloneFunctions)
+        .withDescription("Resolves standalone functions or their class for an import")
+        .withParameters([
+            new SingleParameter("groupName", "Static container group for the functions.", true),
+            new RepeatingParameters("items", [new SingleParameter("item", "An item to import from the group.", true)]),
+        ]);
+
+    /**
+     * @returns Metadata on the command.
+     */
+    public getMetadata(): CommandMetadata {
+        return ImportStandaloneFunctionsCommand.metadata;
+    }
+
+    /**
+     * Renders the command for a language with the given parameters.
+     *
+     * @param parameters   The command's name, followed by any parameters.
+     * @returns Line(s) of code in the language.
+     */
+    public render(parameters: string[]): LineResults {
+        const importParameters: string[] = this.getImportParameters(parameters);
+
+        return LineResults.newSingleLine(importParameters.join(" "), false);
+    }
+
+    private getImportParameters(parameters: string[]): string[] {
+        if (this.language.syntax.standaloneFunctions.withinStaticClass) {
+            return [parameters[1]];
+        }
+
+        const importParameters: string[] = [];
+
+        for (let i = 2; i < parameters.length; i += 1) {
+            const importParameterRaw = parameters[i];
+            const importParameter = this.context.convertStringToCase(
+                importParameterRaw,
+                this.language.syntax.classes.members.functions.publicCase,
+            );
+
+            importParameters.push(importParameter);
+        }
+
+        return importParameters;
+    }
+}

--- a/src/Rendering/Commands/Metadata/Parameters/KeywordParameter.ts
+++ b/src/Rendering/Commands/Metadata/Parameters/KeywordParameter.ts
@@ -1,3 +1,4 @@
+import { CommandNode } from "../../../../Tokenization/Nodes/CommandNode";
 import { IGlsNode } from "../../../../Tokenization/Nodes/IGlsNode";
 import { TextNode } from "../../../../Tokenization/Nodes/TextNode";
 import { IParameter } from "./Parameter";
@@ -44,17 +45,17 @@ export class KeywordParameter implements IParameter {
     /**
      * Validates whether a command's args match this requirement.
      *
-     * @param args   All args of a command.
+     * @param node   Command node with args from a source file.
      * @param inputPosition   Index of a starting input under test.
      * @param requirements   All parameter requirements.
      * @param requirementPosition   Index of the parameter requirement under test.
      * @returns A new input position following all valid inputs.
      */
-    public validate(args: IGlsNode[], inputPosition: number, requirements: IParameter[], requirementPosition: number): number {
-        const inputArg = args[inputPosition];
+    public validate(node: CommandNode, inputPosition: number, requirements: IParameter[], requirementPosition: number): number {
+        const inputArg = node.args[inputPosition];
         if (!(inputArg instanceof TextNode)) {
             if (this.required) {
-                throw new Error("Parameter must be a text keyword.");
+                throw new Error(`${node.command}: Parameter must be a text keyword.`);
             }
 
             return inputPosition;
@@ -65,7 +66,7 @@ export class KeywordParameter implements IParameter {
         }
 
         if (this.required) {
-            throw new Error(`Missing required parameter: must be one of: '${Array.from(this.literals).join("', '")}'`);
+            throw new Error(`${node.command}: Missing required parameter: must be one of: '${Array.from(this.literals).join("', '")}'`);
         }
 
         return inputPosition;

--- a/src/Rendering/Commands/Metadata/Parameters/Parameter.ts
+++ b/src/Rendering/Commands/Metadata/Parameters/Parameter.ts
@@ -1,4 +1,4 @@
-import { IGlsNode } from "../../../../Tokenization/Nodes/IGlsNode";
+import { CommandNode } from "../../../../Tokenization/Nodes/CommandNode";
 
 /**
  * Some parameter(s) to be passed to a command.
@@ -12,11 +12,11 @@ export interface IParameter {
     /**
      * Validates whether a command's args match this requirement.
      *
-     * @param args   All args of a command.
+     * @param node   Command node with args from a source file.
      * @param inputPosition   Index of a starting input under test.
      * @param requirements   All parameter requirements.
      * @param requirementPosition   Index of the parameter requirement under test.
      * @returns A new input position following all valid inputs.
      */
-    validate(args: IGlsNode[], inputPosition: number, requirements: IParameter[], requirementPosition: number): number;
+    validate(command: CommandNode, inputPosition: number, requirements: IParameter[], requirementPosition: number): number;
 }

--- a/src/Rendering/Commands/Metadata/Parameters/SingleParameter.ts
+++ b/src/Rendering/Commands/Metadata/Parameters/SingleParameter.ts
@@ -1,3 +1,4 @@
+import { CommandNode } from "../../../../Tokenization/Nodes/CommandNode";
 import { IParameter } from "./Parameter";
 
 /**
@@ -42,15 +43,15 @@ export class SingleParameter implements IParameter {
     /**
      * Validates whether parameter inputs match this requirement.
      *
-     * @param inputs   All raw parameter inputs.
+     * @param node   Command node with args from a source file.
      * @param inputPosition   Index of a starting input under test.
      * @param requirements   All parameter requirements.
      * @param requirementPosition   Index of the parameter requirement under test.
      * @returns A new input position following all valid inputs.
      */
-    public validate(inputs: string[], inputPosition: number, requirements: IParameter[], requirementPosition: number): number {
-        if (this.required && inputPosition >= inputs.length) {
-            throw new Error(`Missing parameter: '${this.name}'`);
+    public validate(node: CommandNode, inputPosition: number, requirements: IParameter[], requirementPosition: number): number {
+        if (this.required && inputPosition >= node.args.length) {
+            throw new Error(`${node.command}: Missing parameter: '${this.name}'`);
         }
 
         return inputPosition + 1;

--- a/src/Rendering/ParametersValidator.ts
+++ b/src/Rendering/ParametersValidator.ts
@@ -18,7 +18,7 @@ export class ParametersValidator {
         for (let i = 0; i < requirements.length; i += 1) {
             const requirement = requirements[i];
 
-            inputPosition = requirement.validate(node.args, inputPosition, requirements, i);
+            inputPosition = requirement.validate(node, inputPosition, requirements, i);
         }
     }
 }

--- a/test/end-to-end/Standalone Imports/standalone imports.cs
+++ b/test/end-to-end/Standalone Imports/standalone imports.cs
@@ -1,0 +1,5 @@
+//
+using Utilities.Text;
+
+string repeated = TextUtilities.RepeatText("foo", 7);
+//

--- a/test/end-to-end/Standalone Imports/standalone imports.gls
+++ b/test/end-to-end/Standalone Imports/standalone imports.gls
@@ -1,0 +1,5 @@
+-
+import local : Utilities Text use { import standalone functions : TextUtilities RepeatText }
+
+variable : repeated string { standalone function : public TextUtilities RepeatText "foo" 7 }
+-

--- a/test/end-to-end/Standalone Imports/standalone imports.java
+++ b/test/end-to-end/Standalone Imports/standalone imports.java
@@ -1,0 +1,5 @@
+//
+import utilities.text.TextUtilities;
+
+string repeated = TextUtilities.repeatText("foo", 7);
+//

--- a/test/end-to-end/Standalone Imports/standalone imports.js
+++ b/test/end-to-end/Standalone Imports/standalone imports.js
@@ -1,0 +1,5 @@
+//
+import { repeatText } from "./utilities/text";
+
+let repeated = repeatText("foo", 7);
+//

--- a/test/end-to-end/Standalone Imports/standalone imports.py
+++ b/test/end-to-end/Standalone Imports/standalone imports.py
@@ -1,0 +1,5 @@
+#
+from .utilities.text import repeat_text
+
+repeated = repeat_text("foo", 7)
+#

--- a/test/end-to-end/Standalone Imports/standalone imports.rb
+++ b/test/end-to-end/Standalone Imports/standalone imports.rb
@@ -1,0 +1,5 @@
+#
+require_relative "./utilities/text"
+
+repeated = repeat_text("foo", 7)
+#

--- a/test/end-to-end/Standalone Imports/standalone imports.ts
+++ b/test/end-to-end/Standalone Imports/standalone imports.ts
@@ -1,0 +1,5 @@
+//
+import { repeatText } from "./utilities/text";
+
+let repeated: string = repeatText("foo", 7);
+//

--- a/test/integration/ImportLocal/cousin.js
+++ b/test/integration/ImportLocal/cousin.js
@@ -1,4 +1,3 @@
 //
 import { fff, ggg } from "../eee";
-
 //

--- a/test/integration/ImportLocal/cousin.py
+++ b/test/integration/ImportLocal/cousin.py
@@ -1,4 +1,3 @@
 #
 from ..eee import fff, ggg
-
 #

--- a/test/integration/ImportLocal/cousin.rb
+++ b/test/integration/ImportLocal/cousin.rb
@@ -1,4 +1,3 @@
 #
 require_relative "../eee"
-
 #

--- a/test/integration/ImportLocal/cousin.ts
+++ b/test/integration/ImportLocal/cousin.ts
@@ -1,4 +1,3 @@
 //
 import { fff, ggg } from "../eee";
-
 //

--- a/test/integration/ImportLocal/parent sibling.js
+++ b/test/integration/ImportLocal/parent sibling.js
@@ -1,4 +1,3 @@
 //
 import { fff, ggg } from "../../eee";
-
 //

--- a/test/integration/ImportLocal/parent sibling.py
+++ b/test/integration/ImportLocal/parent sibling.py
@@ -1,4 +1,3 @@
 #
 from ...eee import fff, ggg
-
 #

--- a/test/integration/ImportLocal/parent sibling.rb
+++ b/test/integration/ImportLocal/parent sibling.rb
@@ -1,4 +1,3 @@
 #
 require_relative "../../eee"
-
 #

--- a/test/integration/ImportLocal/parent sibling.ts
+++ b/test/integration/ImportLocal/parent sibling.ts
@@ -1,4 +1,3 @@
 //
 import { fff, ggg } from "../../eee";
-
 //

--- a/test/integration/ImportLocal/parent.js
+++ b/test/integration/ImportLocal/parent.js
@@ -1,4 +1,3 @@
 //
 import { eee, fff } from "..";
-
 //

--- a/test/integration/ImportLocal/parent.py
+++ b/test/integration/ImportLocal/parent.py
@@ -1,4 +1,3 @@
 #
 from .. import eee, fff
-
 #

--- a/test/integration/ImportLocal/parent.rb
+++ b/test/integration/ImportLocal/parent.rb
@@ -1,4 +1,3 @@
 #
 require_relative ".."
-
 #

--- a/test/integration/ImportLocal/parent.ts
+++ b/test/integration/ImportLocal/parent.ts
@@ -1,4 +1,3 @@
 //
 import { eee, fff } from "..";
-
 //

--- a/test/integration/ImportLocal/sibling.js
+++ b/test/integration/ImportLocal/sibling.js
@@ -1,4 +1,3 @@
 //
 import { fff, ggg } from "./eee";
-
 //

--- a/test/integration/ImportLocal/sibling.py
+++ b/test/integration/ImportLocal/sibling.py
@@ -1,4 +1,3 @@
 #
 from .eee import fff, ggg
-
 #

--- a/test/integration/ImportLocal/sibling.rb
+++ b/test/integration/ImportLocal/sibling.rb
@@ -1,4 +1,3 @@
 #
 require_relative "./eee"
-
 #

--- a/test/integration/ImportLocal/sibling.ts
+++ b/test/integration/ImportLocal/sibling.ts
@@ -1,4 +1,3 @@
 //
 import { fff, ggg } from "./eee";
-
 //

--- a/util/docs/compileGls.ts
+++ b/util/docs/compileGls.ts
@@ -1,0 +1,78 @@
+import * as fs from "fs";
+// @ts-ignore
+import * as glob from "glob";
+
+import { Gls } from "../../lib/Gls";
+
+interface IFileError {
+    error: Error;
+    filePath: string;
+    position: number;
+}
+
+const blockEnd = "\n```";
+const blockStart = "```gls";
+
+const gls = new Gls("C#");
+
+const validateFileSection = (filePath: string, fileContents: string, start: number, fileErrors: IFileError[]) => {
+    const codeStart = start + blockStart.length;
+    const codeEnd = fileContents.indexOf(blockEnd, codeStart);
+    const codeContents = fileContents
+        .substring(codeStart, codeEnd)
+        .trim()
+        .split(/\r\n|\r|\n/g);
+
+    try {
+        gls.convert(codeContents);
+    } catch (error) {
+        fileErrors.push({
+            error,
+            filePath,
+            position: codeStart,
+        });
+    }
+
+    return codeEnd;
+};
+
+const validateFile = (filePath: string, fileErrors: IFileError[]) => {
+    const fileContents = fs.readFileSync(filePath).toString();
+    let start = 0;
+
+    while (true) {
+        start = fileContents.indexOf(blockStart, start);
+
+        if (start === -1) {
+            break;
+        }
+
+        start = validateFileSection(filePath, fileContents, start, fileErrors);
+    }
+};
+
+const validateAllFiles = () => {
+    const filePaths = [...glob.sync("docs/**/*.md"), "README.md"];
+    const fileErrors: IFileError[] = [];
+
+    for (const filePath of filePaths) {
+        validateFile(filePath, fileErrors);
+    }
+
+    let hadError: boolean = false;
+
+    for (const fileError of fileErrors) {
+        // Docs are allowed to contain unsupported syntax commands
+        if (fileError.error.message.indexOf("Unsupported syntax:") !== -1) {
+            continue;
+        }
+
+        hadError = true;
+        console.error(`Could not compile GLS code block in ${fileError.filePath} at position ${fileError.position}:`);
+        console.error(`${fileError.error.stack}\n`);
+    }
+
+    process.exitCode = hadError ? 1 : 0;
+};
+
+validateAllFiles();


### PR DESCRIPTION
Finds all gls code blocks in docs and compiles them with GLS as part of the docs build.
Finishes adding the ImportStandaloneFunctions command I had neglected to earlier.

Fixes #272.