### PR TITLE
Added accessors for Ruby variables

### DIFF
--- a/src/Rendering/Commands/MemberVariableDeclareCommand.ts
+++ b/src/Rendering/Commands/MemberVariableDeclareCommand.ts
@@ -63,9 +63,17 @@ export class MemberVariableDeclareCommand extends Command {
         variableName = this.context.convertStringToCase(variableName, casingStyle);
 
         const inlineParameters = [CommandNames.VariableInline, variableName, type];
+        const variableLine = this.context.convertParsed(inlineParameters);
+        const variableText = variableLine.commandResults[0].text;
 
-        output += this.context.convertParsed(inlineParameters).commandResults[0].text;
+        if (variableText === "\0") {
+            output += variableName;
+        } else {
+            output += variableText;
+        }
 
-        return LineResults.newSingleLine(output).withAddSemicolon(true);
+        return LineResults.newSingleLine(output)
+            .withAddSemicolon(true)
+            .withImports(variableLine.addedImports);
     }
 }

--- a/src/Rendering/Languages/Ruby.ts
+++ b/src/Rendering/Languages/Ruby.ts
@@ -151,15 +151,15 @@ export class Ruby extends Language {
      */
     protected generateClassMemberVariableSyntax(variables: ClassMemberVariableSyntax): void {
         variables.publicPrefix = "";
-        variables.skipMemberVariables = true;
+        variables.skipMemberVariables = false;
 
-        variables.private = "";
+        variables.private = "attr_accessor: ";
         variables.privateCase = CaseStyle.CamelCase;
         variables.privatePrefix = "";
-        variables.protected = "";
+        variables.protected = "attr_accessor: ";
         variables.protectedCase = CaseStyle.CamelCase;
         variables.protectedPrefix = "";
-        variables.public = "";
+        variables.public = "attr_accessor: ";
         variables.publicCase = CaseStyle.CamelCase;
         variables.publicPrefix = "";
     }

--- a/test/end-to-end/Point/Point.rb
+++ b/test/end-to-end/Point/Point.rb
@@ -1,5 +1,9 @@
 #
 class Point
+    attr_accessor: x
+    attr_accessor: y
+    attr_accessor: square
+    attr_accessor: name
 
     def initialize(x, y)
         self.x = x

--- a/test/integration/MemberVariableDeclare/private.rb
+++ b/test/integration/MemberVariableDeclare/private.rb
@@ -1,2 +1,3 @@
 #
+attr_accessor: aaa
 #

--- a/test/integration/MemberVariableDeclare/protected.rb
+++ b/test/integration/MemberVariableDeclare/protected.rb
@@ -1,2 +1,3 @@
 #
+attr_accessor: aaa
 #

--- a/test/integration/MemberVariableDeclare/public.rb
+++ b/test/integration/MemberVariableDeclare/public.rb
@@ -1,2 +1,3 @@
 #
+attr_accessor: aaa
 #


### PR DESCRIPTION
Seems to pacify end-to-end tests. Starts on #496, but also adds it to protected and private members. Will need to investigate more (#59). 